### PR TITLE
[#9] 상품 재고 예약, 차감, 차감 롤백 기능 개발

### DIFF
--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation 'org.projectlombok:lombok:1.18.28'
+    testImplementation 'org.projectlombok:lombok:1.18.30'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -35,6 +35,8 @@ dependencies {
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     testImplementation 'com.h2database:h2'
     testImplementation 'org.mockito:mockito-core'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/product-service/docker-compose.yml
+++ b/product-service/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_DATABASE=be_product
+      - MYSQL_ROOT_PASSWORD=root
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - be-network
+
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - "6379:6379"
+    command: redis-server --requirepass password123
+    volumes:
+      - redis_data:/data
+    networks:
+      - be-network
+
+volumes:
+  mysql_data:
+  redis_data:
+
+networks:
+  be-network:
+    driver: bridge

--- a/product-service/src/main/java/com/ed/productservice/application/port/out/ProductOutPort.java
+++ b/product-service/src/main/java/com/ed/productservice/application/port/out/ProductOutPort.java
@@ -6,4 +6,6 @@ import com.ed.productservice.domain.vo.Product;
 public interface ProductOutPort {
 
     Product createProduct(ProductForCreate productForCreate, Long brandId);
+
+    Product findOne(Long productId);
 }

--- a/product-service/src/main/java/com/ed/productservice/application/service/internal/ProductInternalService.java
+++ b/product-service/src/main/java/com/ed/productservice/application/service/internal/ProductInternalService.java
@@ -1,0 +1,99 @@
+package com.ed.productservice.application.service.internal;
+
+import static com.ed.productservice.libs.common.ErrorCode.INVENTORY_RESERVATION_FAILED;
+import static com.ed.productservice.libs.common.ErrorCode.STOCK_RESERVATION_NOT_FOUND;
+
+import com.ed.productservice.application.port.out.ProductOutPort;
+import com.ed.productservice.domain.vo.Product;
+import com.ed.productservice.domain.vo.ProductCategory;
+import com.ed.productservice.domain.vo.ProductReservationInfoDomain;
+import com.ed.productservice.libs.common.ProductException;
+import com.ed.productservice.presentation.web.request.InventoryReservationRequest;
+import com.ed.productservice.presentation.web.request.InventoryReservationRequest.ProductReservationInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProductInternalService {
+
+    private final ProductOutPort productOutPort;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final StockService stockService;
+    private final ObjectMapper objectMapper;
+    private final String STOCK_RESERVATION = "product-stock:reservation:";
+
+    @Transactional
+    public String reservation(InventoryReservationRequest request) {
+        String reservationId = UUID.randomUUID().toString();
+
+        try {
+            List<ProductReservationInfo> items = request.items();
+            for (ProductReservationInfo item : items) {
+
+                Product product = productOutPort.findOne(item.productId());
+                ProductCategory category = product.getCategory();
+
+                stockService.stockReservation(item, category);
+
+                saveStockReservation(item, reservationId, category);
+            }
+        } catch (Exception e) {
+            redisTemplate.delete(STOCK_RESERVATION + reservationId);
+            log.error("reservationId = {}, error message = {}", reservationId, e.getMessage());
+            throw new ProductException(INVENTORY_RESERVATION_FAILED);
+        }
+
+        return reservationId;
+    }
+
+    @Transactional
+    public String decreaseStock(String reservationId) throws JsonProcessingException {
+        String key = STOCK_RESERVATION + reservationId;
+
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+        if (entries.isEmpty()) {
+            throw new ProductException(STOCK_RESERVATION_NOT_FOUND);
+        }
+
+        for (Entry<Object, Object> entry : entries.entrySet()) {
+            ProductReservationInfoDomain productReservationInfo = objectMapper.readValue(
+                entry.getValue().toString(), ProductReservationInfoDomain.class);
+
+            stockService.decreaseStockReservation(productReservationInfo, reservationId);
+        }
+
+        return reservationId;
+    }
+
+    @Transactional
+    public String increaseStock(String reservationId) {
+        stockService.increase(reservationId);
+
+        return reservationId;
+    }
+
+
+    private void saveStockReservation(ProductReservationInfo item, String reservationId,
+        ProductCategory category)
+        throws JsonProcessingException {
+        String key = STOCK_RESERVATION + reservationId;
+
+        redisTemplate.opsForHash()
+            .put(key, item.productId().toString(),
+                objectMapper.writeValueAsString(ProductReservationInfoDomain.of(item, category)));
+
+        redisTemplate.expire(key, Duration.ofHours(1));
+    }
+}

--- a/product-service/src/main/java/com/ed/productservice/application/service/internal/ProductInternalService.java
+++ b/product-service/src/main/java/com/ed/productservice/application/service/internal/ProductInternalService.java
@@ -79,7 +79,7 @@ public class ProductInternalService {
 
     @Transactional
     public String increaseStock(String reservationId) {
-        stockService.increase(reservationId);
+        stockService.increaseStock(reservationId);
 
         return reservationId;
     }

--- a/product-service/src/main/java/com/ed/productservice/application/service/internal/ProductInternalService.java
+++ b/product-service/src/main/java/com/ed/productservice/application/service/internal/ProductInternalService.java
@@ -89,10 +89,9 @@ public class ProductInternalService {
         ProductCategory category)
         throws JsonProcessingException {
         String key = STOCK_RESERVATION + reservationId;
+        String hashKey = item.productId() + ":" + item.size();
 
-        redisTemplate.opsForHash()
-            .put(key, item.productId().toString(),
-                objectMapper.writeValueAsString(ProductReservationInfoDomain.of(item, category)));
+        redisTemplate.opsForHash().put(key, hashKey, objectMapper.writeValueAsString(ProductReservationInfoDomain.of(item, category)));
 
         redisTemplate.expire(key, Duration.ofHours(1));
     }

--- a/product-service/src/main/java/com/ed/productservice/application/service/internal/StockService.java
+++ b/product-service/src/main/java/com/ed/productservice/application/service/internal/StockService.java
@@ -1,0 +1,64 @@
+package com.ed.productservice.application.service.internal;
+
+import com.ed.productservice.domain.vo.ProductCategory;
+import com.ed.productservice.domain.vo.ProductReservationInfoDomain;
+import com.ed.productservice.infrastructure.persistence.adapter.internal.BottomSizeStockAdapter;
+import com.ed.productservice.infrastructure.persistence.adapter.internal.TopSizeStockAdapter;
+import com.ed.productservice.infrastructure.persistence.adapter.internal.StockAdapter;
+import com.ed.productservice.presentation.web.request.InventoryReservationRequest.ProductReservationInfo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StockService {
+
+    private final TopSizeStockAdapter topSizeStockAdapter;
+    private final BottomSizeStockAdapter bottomSizeStockAdapter;
+    private final StockAdapter stockAdapter;
+
+
+    public void stockReservation(ProductReservationInfo item, ProductCategory category) {
+        if (category.equals(ProductCategory.BOTTOM)) {
+            bottomSizeStockAdapter.bottomPrepare(item);
+        }
+
+        if (category.equals(ProductCategory.TOP)) {
+            topSizeStockAdapter.topProductPrepare(item);
+        }
+    }
+
+    public void decreaseStockReservation(ProductReservationInfoDomain productReservationInfo,
+        String reservationId) {
+        stockAdapter.isDuplicateStockDecrease(productReservationInfo, reservationId);
+
+        ProductCategory category = productReservationInfo.getProductCategory();
+        if (category.equals(ProductCategory.TOP)) {
+            topSizeStockAdapter.topDecreaseStock(productReservationInfo);
+        }
+
+        if (category.equals(ProductCategory.BOTTOM)) {
+            bottomSizeStockAdapter.bottomDecreaseStock(productReservationInfo);
+        }
+
+        stockAdapter.save(productReservationInfo, reservationId);
+    }
+
+    public void increase(String reservationId) {
+        List<ProductReservationInfoDomain> itemList = stockAdapter.findAllByReservationId(
+            reservationId);
+
+        for (ProductReservationInfoDomain item : itemList) {
+            if (item.getProductCategory().equals(ProductCategory.TOP)) {
+                topSizeStockAdapter.topIncrease(item);
+            }
+
+            if (item.getProductCategory().equals(ProductCategory.BOTTOM)) {
+                bottomSizeStockAdapter.bottomIncrease(item);
+            }
+
+            stockAdapter.deleteStockHistory(reservationId);
+        }
+    }
+}

--- a/product-service/src/main/java/com/ed/productservice/application/service/internal/StockService.java
+++ b/product-service/src/main/java/com/ed/productservice/application/service/internal/StockService.java
@@ -45,7 +45,7 @@ public class StockService {
         stockAdapter.save(productReservationInfo, reservationId);
     }
 
-    public void increase(String reservationId) {
+    public void increaseStock(String reservationId) {
         List<ProductReservationInfoDomain> itemList = stockAdapter.findAllByReservationId(
             reservationId);
 

--- a/product-service/src/main/java/com/ed/productservice/application/service/internal/StockService.java
+++ b/product-service/src/main/java/com/ed/productservice/application/service/internal/StockService.java
@@ -1,10 +1,13 @@
 package com.ed.productservice.application.service.internal;
 
+import static com.ed.productservice.libs.common.ErrorCode.STOCK_RESERVATION_NOT_FOUND;
+
 import com.ed.productservice.domain.vo.ProductCategory;
 import com.ed.productservice.domain.vo.ProductReservationInfoDomain;
 import com.ed.productservice.infrastructure.persistence.adapter.internal.BottomSizeStockAdapter;
 import com.ed.productservice.infrastructure.persistence.adapter.internal.TopSizeStockAdapter;
 import com.ed.productservice.infrastructure.persistence.adapter.internal.StockAdapter;
+import com.ed.productservice.libs.common.ProductException;
 import com.ed.productservice.presentation.web.request.InventoryReservationRequest.ProductReservationInfo;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +51,10 @@ public class StockService {
     public void increaseStock(String reservationId) {
         List<ProductReservationInfoDomain> itemList = stockAdapter.findAllByReservationId(
             reservationId);
+
+        if (itemList.isEmpty()) {
+            throw new ProductException(STOCK_RESERVATION_NOT_FOUND);
+        }
 
         for (ProductReservationInfoDomain item : itemList) {
             if (item.getProductCategory().equals(ProductCategory.TOP)) {

--- a/product-service/src/main/java/com/ed/productservice/domain/BottomProduct.java
+++ b/product-service/src/main/java/com/ed/productservice/domain/BottomProduct.java
@@ -24,13 +24,16 @@ public class BottomProduct {
         private BigDecimal hipWidth;
         private BigDecimal thighWidth;
         private BigDecimal bottomTotalLength;
+        private Integer quantity;
 
-        public BottomSize(String bottomSize, BigDecimal waistWidth, BigDecimal hipWidth, BigDecimal thighWidth, BigDecimal bottomTotalLength) {
+        public BottomSize(String bottomSize, BigDecimal waistWidth, BigDecimal hipWidth,
+            BigDecimal thighWidth, BigDecimal bottomTotalLength, Integer quantity) {
             this.bottomSize = bottomSize;
             this.waistWidth = waistWidth;
             this.hipWidth = hipWidth;
             this.thighWidth = thighWidth;
             this.bottomTotalLength = bottomTotalLength;
+            this.quantity = quantity;
         }
     }
 }

--- a/product-service/src/main/java/com/ed/productservice/domain/TopProduct.java
+++ b/product-service/src/main/java/com/ed/productservice/domain/TopProduct.java
@@ -22,13 +22,17 @@ public class TopProduct {
         private BigDecimal shoulderWidth;
         private BigDecimal chestWidth;
         private BigDecimal sleeveLength;
+        private Integer quantity;
 
-        public TopSize(String topSize, BigDecimal totalLength, BigDecimal shoulderWidth, BigDecimal chestWidth, BigDecimal sleeveLength) {
+
+        public TopSize(String topSize, BigDecimal totalLength, BigDecimal shoulderWidth,
+            BigDecimal chestWidth, BigDecimal sleeveLength, Integer quantity) {
             this.topSize = topSize;
             this.totalLength = totalLength;
             this.shoulderWidth = shoulderWidth;
             this.chestWidth = chestWidth;
             this.sleeveLength = sleeveLength;
+            this.quantity = quantity;
         }
     }
 }

--- a/product-service/src/main/java/com/ed/productservice/domain/vo/Product.java
+++ b/product-service/src/main/java/com/ed/productservice/domain/vo/Product.java
@@ -19,7 +19,6 @@ public class Product {
     private int price;
     private String description;
     private String color;
-    private Integer quantity;
     private String image;
     private ProductStatus status;
     private ProductCategory category;

--- a/product-service/src/main/java/com/ed/productservice/domain/vo/ProductReservationInfoDomain.java
+++ b/product-service/src/main/java/com/ed/productservice/domain/vo/ProductReservationInfoDomain.java
@@ -1,0 +1,42 @@
+package com.ed.productservice.domain.vo;
+
+import com.ed.productservice.infrastructure.persistence.entity.StockDecreaseHistoryEntity;
+import com.ed.productservice.presentation.web.request.InventoryReservationRequest.ProductReservationInfo;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductReservationInfoDomain {
+    private Long productId;
+    private int quantity;
+    private String size;
+    private ProductCategory productCategory;
+
+    public ProductReservationInfoDomain(Long productId, int quantity, String size,
+        ProductCategory productCategory) {
+        this.productId = productId;
+        this.quantity = quantity;
+        this.size = size;
+        this.productCategory = productCategory;
+    }
+
+    public static ProductReservationInfoDomain of(ProductReservationInfo item, ProductCategory category) {
+        return new ProductReservationInfoDomain(
+            item.productId(),
+            item.quantity(),
+            item.size(),
+            category
+        );
+    }
+
+
+    public static ProductReservationInfoDomain from(StockDecreaseHistoryEntity entity) {
+        return new ProductReservationInfoDomain(
+            entity.getProductId(),
+            entity.getQuantity(),
+            entity.getSize(),
+            entity.getProductCategory(
+            ));
+    }
+}

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/BrandAdapter.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/BrandAdapter.java
@@ -5,7 +5,7 @@ import com.ed.productservice.domain.vo.Brand;
 import com.ed.productservice.infrastructure.persistence.adapter.mapper.BrandMapper;
 import com.ed.productservice.infrastructure.persistence.entity.BrandEntity;
 import com.ed.productservice.infrastructure.persistence.repository.BrandRepository;
-import com.ed.productservice.libs.common.BrandNotFoundException;
+import com.ed.productservice.libs.common.BrandException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -19,7 +19,7 @@ public class BrandAdapter implements BrandOutPort {
 
     @Override
     public Brand findOne(Long brandId) {
-        BrandEntity entity = brandRepository.findById(brandId).orElseThrow(() -> new BrandNotFoundException(BRAND_NOT_FOUND));
+        BrandEntity entity = brandRepository.findById(brandId).orElseThrow(() -> new BrandException(BRAND_NOT_FOUND));
 
         return brandMapper.toDomain(entity);
     }

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/ProductAdapter.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/ProductAdapter.java
@@ -1,11 +1,14 @@
 package com.ed.productservice.infrastructure.persistence.adapter;
 
+import static com.ed.productservice.libs.common.ErrorCode.PRODUCT_NOT_FOUND;
+
 import com.ed.productservice.application.port.out.ProductOutPort;
 import com.ed.productservice.domain.ProductForCreate;
 import com.ed.productservice.domain.vo.Product;
 import com.ed.productservice.infrastructure.persistence.adapter.mapper.ProductMapper;
 import com.ed.productservice.infrastructure.persistence.entity.ProductEntity;
 import com.ed.productservice.infrastructure.persistence.repository.ProductRepository;
+import com.ed.productservice.libs.common.ProductException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -20,5 +23,13 @@ public class ProductAdapter implements ProductOutPort {
         ProductEntity entity = productMapper.from(productForCreate, brandId);
 
         return productMapper.toDomain(productRepository.save(entity));
+    }
+
+    @Override
+    public Product findOne(Long productId) {
+        ProductEntity entity = productRepository.findById(productId)
+            .orElseThrow(() -> new ProductException(PRODUCT_NOT_FOUND));
+
+        return productMapper.toDomain(entity);
     }
 }

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/ProductDetailAdapter.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/ProductDetailAdapter.java
@@ -5,29 +5,29 @@ import com.ed.productservice.domain.BottomProduct;
 import com.ed.productservice.domain.TopProduct;
 import com.ed.productservice.infrastructure.persistence.adapter.mapper.BottomSizeMapper;
 import com.ed.productservice.infrastructure.persistence.adapter.mapper.TopSizeMapper;
-import com.ed.productservice.infrastructure.persistence.repository.BottomSizeRepository;
-import com.ed.productservice.infrastructure.persistence.repository.TopSizeRepository;
+import com.ed.productservice.infrastructure.persistence.repository.BottomSizeStockRepository;
+import com.ed.productservice.infrastructure.persistence.repository.TopSizeStockRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class ProductDetailAdapter implements ProductDetailPort {
-    private final TopSizeRepository topSizeRepository;
-    private final BottomSizeRepository bottomSizeRepository;
+    private final TopSizeStockRepository topSizeStockRepository;
+    private final BottomSizeStockRepository bottomSizeStockRepository;
     private final TopSizeMapper topSizeMapper;
     private final BottomSizeMapper bottomSizeMapper;
 
     @Override
     public void saveTopSize(Long productId, TopProduct topProduct) {
         topProduct.getTopSizeList()
-                .forEach(topSize -> topSizeRepository.save(topSizeMapper.from(productId, topSize)));
+                .forEach(topSize -> topSizeStockRepository.save(topSizeMapper.from(productId, topSize)));
     }
 
     @Override
     public void saveBottomSize(Long productId, BottomProduct bottomProduct) {
         bottomProduct.getBottomSizeList()
-                .forEach(bottomSize -> bottomSizeRepository.save(bottomSizeMapper.from(productId, bottomSize)));
+                .forEach(bottomSize -> bottomSizeStockRepository.save(bottomSizeMapper.from(productId, bottomSize)));
     }
 }
 

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/internal/BottomSizeStockAdapter.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/internal/BottomSizeStockAdapter.java
@@ -1,0 +1,39 @@
+package com.ed.productservice.infrastructure.persistence.adapter.internal;
+
+import com.ed.productservice.domain.vo.ProductReservationInfoDomain;
+import com.ed.productservice.infrastructure.persistence.entity.size.BottomSizeStockEntity;
+import com.ed.productservice.infrastructure.persistence.entity.size.TopSizeStockEntity;
+import com.ed.productservice.infrastructure.persistence.repository.BottomSizeRepository;
+import com.ed.productservice.presentation.web.request.InventoryReservationRequest.ProductReservationInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BottomSizeStockAdapter {
+
+    private final BottomSizeRepository bottomSizeRepository;
+
+    public void bottomPrepare(ProductReservationInfo item) {
+        BottomSizeStockEntity bottomSizeStockEntity = bottomSizeRepository.findByProductIdAndBottomSize(
+            item.productId(), item.size());
+
+        bottomSizeStockEntity.validateStockAvailability(item.quantity());
+    }
+
+    public void bottomDecreaseStock(ProductReservationInfoDomain reservationInfo) {
+        BottomSizeStockEntity bottomSizeStockEntity = bottomSizeRepository.findByProductIdAndBottomSize(
+            reservationInfo.getProductId(),
+            reservationInfo.getSize());
+
+        bottomSizeStockEntity.decrease(reservationInfo.getQuantity());
+    }
+
+    public void bottomIncrease(ProductReservationInfoDomain item) {
+        BottomSizeStockEntity entity = bottomSizeRepository.findByProductIdAndBottomSize(
+            item.getProductId(),
+            item.getSize());
+
+        entity.increaseStock(item.getQuantity());
+    }
+}

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/internal/BottomSizeStockAdapter.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/internal/BottomSizeStockAdapter.java
@@ -2,8 +2,7 @@ package com.ed.productservice.infrastructure.persistence.adapter.internal;
 
 import com.ed.productservice.domain.vo.ProductReservationInfoDomain;
 import com.ed.productservice.infrastructure.persistence.entity.size.BottomSizeStockEntity;
-import com.ed.productservice.infrastructure.persistence.entity.size.TopSizeStockEntity;
-import com.ed.productservice.infrastructure.persistence.repository.BottomSizeRepository;
+import com.ed.productservice.infrastructure.persistence.repository.BottomSizeStockRepository;
 import com.ed.productservice.presentation.web.request.InventoryReservationRequest.ProductReservationInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,17 +11,17 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class BottomSizeStockAdapter {
 
-    private final BottomSizeRepository bottomSizeRepository;
+    private final BottomSizeStockRepository bottomSizeStockRepository;
 
     public void bottomPrepare(ProductReservationInfo item) {
-        BottomSizeStockEntity bottomSizeStockEntity = bottomSizeRepository.findByProductIdAndBottomSize(
+        BottomSizeStockEntity bottomSizeStockEntity = bottomSizeStockRepository.findByProductIdAndBottomSize(
             item.productId(), item.size());
 
         bottomSizeStockEntity.validateStockAvailability(item.quantity());
     }
 
     public void bottomDecreaseStock(ProductReservationInfoDomain reservationInfo) {
-        BottomSizeStockEntity bottomSizeStockEntity = bottomSizeRepository.findByProductIdAndBottomSize(
+        BottomSizeStockEntity bottomSizeStockEntity = bottomSizeStockRepository.findByProductIdAndBottomSize(
             reservationInfo.getProductId(),
             reservationInfo.getSize());
 
@@ -30,7 +29,7 @@ public class BottomSizeStockAdapter {
     }
 
     public void bottomIncrease(ProductReservationInfoDomain item) {
-        BottomSizeStockEntity entity = bottomSizeRepository.findByProductIdAndBottomSize(
+        BottomSizeStockEntity entity = bottomSizeStockRepository.findByProductIdAndBottomSize(
             item.getProductId(),
             item.getSize());
 

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/internal/StockAdapter.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/internal/StockAdapter.java
@@ -1,0 +1,52 @@
+package com.ed.productservice.infrastructure.persistence.adapter.internal;
+
+import static com.ed.productservice.libs.common.ErrorCode.*;
+
+import com.ed.productservice.domain.vo.ProductReservationInfoDomain;
+import com.ed.productservice.infrastructure.persistence.entity.BaseEntity;
+import com.ed.productservice.infrastructure.persistence.entity.StockDecreaseHistoryEntity;
+import com.ed.productservice.infrastructure.persistence.repository.StockDecreaseHistoryRepository;
+import com.ed.productservice.libs.common.ProductException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StockAdapter {
+
+    private final StockDecreaseHistoryRepository stockDecreaseHistoryRepository;
+
+    public void save(ProductReservationInfoDomain productReservationInfo, String reservationId) {
+        stockDecreaseHistoryRepository.save(
+            new StockDecreaseHistoryEntity(
+                productReservationInfo.getProductId(),
+                productReservationInfo.getQuantity(),
+                productReservationInfo.getSize(),
+                productReservationInfo.getProductCategory(),
+                reservationId));
+    }
+
+    public List<ProductReservationInfoDomain> findAllByReservationId(String reservationId) {
+        List<StockDecreaseHistoryEntity> entityList = stockDecreaseHistoryRepository.findAllByReservationId(
+            reservationId);
+
+        return entityList.stream()
+            .map(ProductReservationInfoDomain::from)
+            .toList();
+    }
+
+    public void deleteStockHistory(String reservationId) {
+        stockDecreaseHistoryRepository.findAllByReservationId(
+            reservationId).forEach(BaseEntity::deletedFrom);
+    }
+
+    public void isDuplicateStockDecrease(ProductReservationInfoDomain productReservationInfo, String reservationId) {
+        if (!stockDecreaseHistoryRepository.findByProductIdAndSizeAndReservationId(
+                productReservationInfo.getProductId(), productReservationInfo.getSize(), reservationId)
+            .isEmpty()) {
+
+            throw new ProductException(INVENTORY_ALREADY_DECREASE);
+        }
+    }
+}

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/internal/TopSizeStockAdapter.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/internal/TopSizeStockAdapter.java
@@ -2,7 +2,7 @@ package com.ed.productservice.infrastructure.persistence.adapter.internal;
 
 import com.ed.productservice.domain.vo.ProductReservationInfoDomain;
 import com.ed.productservice.infrastructure.persistence.entity.size.TopSizeStockEntity;
-import com.ed.productservice.infrastructure.persistence.repository.TopSizeRepository;
+import com.ed.productservice.infrastructure.persistence.repository.TopSizeStockRepository;
 import com.ed.productservice.presentation.web.request.InventoryReservationRequest.ProductReservationInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TopSizeStockAdapter {
 
-    private final TopSizeRepository topSizeRepository;
+    private final TopSizeStockRepository topSizeStockRepository;
 
     public void topProductPrepare(ProductReservationInfo item) {
-        TopSizeStockEntity topSizeStockEntity = topSizeRepository.findByProductIdAndTopSize(
+        TopSizeStockEntity topSizeStockEntity = topSizeStockRepository.findByProductIdAndTopSize(
             item.productId(), item.size());
 
         topSizeStockEntity.validateStockAvailability(item.quantity());
@@ -22,7 +22,7 @@ public class TopSizeStockAdapter {
     }
 
     public void topDecreaseStock(ProductReservationInfoDomain reservationInfo) {
-        TopSizeStockEntity topSizeStockEntity = topSizeRepository.findByProductIdAndTopSize(
+        TopSizeStockEntity topSizeStockEntity = topSizeStockRepository.findByProductIdAndTopSize(
             reservationInfo.getProductId(),
             reservationInfo.getSize());
 
@@ -32,7 +32,7 @@ public class TopSizeStockAdapter {
 
 
     public void topIncrease(ProductReservationInfoDomain item) {
-        TopSizeStockEntity entity = topSizeRepository.findByProductIdAndTopSize(item.getProductId(),
+        TopSizeStockEntity entity = topSizeStockRepository.findByProductIdAndTopSize(item.getProductId(),
             item.getSize());
 
         entity.increaseStock(item.getQuantity());

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/internal/TopSizeStockAdapter.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/internal/TopSizeStockAdapter.java
@@ -1,0 +1,40 @@
+package com.ed.productservice.infrastructure.persistence.adapter.internal;
+
+import com.ed.productservice.domain.vo.ProductReservationInfoDomain;
+import com.ed.productservice.infrastructure.persistence.entity.size.TopSizeStockEntity;
+import com.ed.productservice.infrastructure.persistence.repository.TopSizeRepository;
+import com.ed.productservice.presentation.web.request.InventoryReservationRequest.ProductReservationInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TopSizeStockAdapter {
+
+    private final TopSizeRepository topSizeRepository;
+
+    public void topProductPrepare(ProductReservationInfo item) {
+        TopSizeStockEntity topSizeStockEntity = topSizeRepository.findByProductIdAndTopSize(
+            item.productId(), item.size());
+
+        topSizeStockEntity.validateStockAvailability(item.quantity());
+
+    }
+
+    public void topDecreaseStock(ProductReservationInfoDomain reservationInfo) {
+        TopSizeStockEntity topSizeStockEntity = topSizeRepository.findByProductIdAndTopSize(
+            reservationInfo.getProductId(),
+            reservationInfo.getSize());
+
+        topSizeStockEntity.decreaseStock(reservationInfo.getQuantity());
+
+    }
+
+
+    public void topIncrease(ProductReservationInfoDomain item) {
+        TopSizeStockEntity entity = topSizeRepository.findByProductIdAndTopSize(item.getProductId(),
+            item.getSize());
+
+        entity.increaseStock(item.getQuantity());
+    }
+}

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/mapper/BottomSizeMapper.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/mapper/BottomSizeMapper.java
@@ -1,18 +1,19 @@
 package com.ed.productservice.infrastructure.persistence.adapter.mapper;
 
 import com.ed.productservice.domain.BottomProduct;
-import com.ed.productservice.infrastructure.persistence.entity.size.BottomSizeEntity;
+import com.ed.productservice.infrastructure.persistence.entity.size.BottomSizeStockEntity;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BottomSizeMapper {
-    public BottomSizeEntity from(Long productId, BottomProduct.BottomSize bottomSize) {
-        return new BottomSizeEntity(
+    public BottomSizeStockEntity from(Long productId, BottomProduct.BottomSize bottomSize) {
+        return new BottomSizeStockEntity(
                 productId,
                 bottomSize.getBottomSize(),
                 bottomSize.getBottomTotalLength(),
                 bottomSize.getThighWidth(),
-                bottomSize.getHipWidth()
+                bottomSize.getHipWidth(),
+                bottomSize.getQuantity()
         );
     }
 }

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/mapper/ProductMapper.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/mapper/ProductMapper.java
@@ -17,7 +17,6 @@ public class ProductMapper {
                 .price(productForCreate.getPrice())
                 .description(productForCreate.getDescription())
                 .color(productForCreate.getColor())
-                .quantity(productForCreate.getQuantity())
                 .image(productForCreate.getImage())
                 .status(productForCreate.getStatus())
                 .category(productForCreate.getCategory())
@@ -37,7 +36,6 @@ public class ProductMapper {
                 entity.getPrice(),
                 entity.getDescription(),
                 entity.getColor(),
-                entity.getQuantity(),
                 entity.getImage(),
                 entity.getStatus(),
                 entity.getCategory(),

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/mapper/TopSizeMapper.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/adapter/mapper/TopSizeMapper.java
@@ -1,19 +1,20 @@
 package com.ed.productservice.infrastructure.persistence.adapter.mapper;
 
 import com.ed.productservice.domain.TopProduct;
-import com.ed.productservice.infrastructure.persistence.entity.size.TopSizeEntity;
+import com.ed.productservice.infrastructure.persistence.entity.size.TopSizeStockEntity;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TopSizeMapper {
-    public TopSizeEntity from(Long productId, TopProduct.TopSize topSize) {
-        return new TopSizeEntity(
+    public TopSizeStockEntity from(Long productId, TopProduct.TopSize topSize) {
+        return new TopSizeStockEntity(
                 productId,
                 topSize.getTopSize(),
                 topSize.getTotalLength(),
                 topSize.getShoulderWidth(),
                 topSize.getChestWidth(),
-                topSize.getSleeveLength()
+                topSize.getSleeveLength(),
+                topSize.getQuantity()
         );
     }
 }

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/BaseEntity.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/BaseEntity.java
@@ -41,4 +41,9 @@ public class BaseEntity {
     protected void updatedFrom(Long updatedBy) {
         this.updatedBy = updatedBy;
     }
+
+    public void deletedFrom() {
+        this.deletedAt = LocalDateTime.now();
+        this.isDeleted = true;
+    }
 }

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/ProductEntity.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/ProductEntity.java
@@ -2,7 +2,13 @@ package com.ed.productservice.infrastructure.persistence.entity;
 
 import com.ed.productservice.domain.vo.ProductCategory;
 import com.ed.productservice.domain.vo.ProductStatus;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,7 +30,6 @@ public class ProductEntity extends BaseEntity {
     private int price;
     private String description;
     private String color;
-    private Integer quantity;
     private String image;
 
     @Enumerated(EnumType.STRING)
@@ -32,14 +37,15 @@ public class ProductEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ProductCategory category;
 
-    public ProductEntity(String productPublicId, Long brandId, String name, int price, String description, String color, Integer quantity, String image, ProductStatus status, ProductCategory category) {
+    public ProductEntity(String productPublicId, Long brandId, String name, int price,
+        String description, String color, String image, ProductStatus status,
+        ProductCategory category) {
         this.productPublicId = productPublicId;
         this.brandId = brandId;
         this.name = name;
         this.price = price;
         this.description = description;
         this.color = color;
-        this.quantity = quantity;
         this.image = image;
         this.status = status;
         this.category = category;

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/StockDecreaseHistoryEntity.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/StockDecreaseHistoryEntity.java
@@ -1,0 +1,41 @@
+package com.ed.productservice.infrastructure.persistence.entity;
+
+import com.ed.productservice.domain.vo.ProductCategory;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Table(name = "ed_stock_decrease_history")
+@Entity
+@NoArgsConstructor
+public class StockDecreaseHistoryEntity extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long productId;
+    private Integer quantity;
+    private String size;
+
+    @Enumerated(EnumType.STRING)
+    private ProductCategory productCategory;
+
+    private String reservationId;
+
+    public StockDecreaseHistoryEntity(Long productId, Integer quantity, String size,
+        ProductCategory productCategory, String reservationId) {
+        this.productId = productId;
+        this.quantity = quantity;
+        this.size = size;
+        this.productCategory = productCategory;
+        this.reservationId = reservationId;
+    }
+}

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/size/BottomSizeStockEntity.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/size/BottomSizeStockEntity.java
@@ -1,6 +1,9 @@
 package com.ed.productservice.infrastructure.persistence.entity.size;
 
+import static com.ed.productservice.libs.common.ErrorCode.INSUFFICIENT_PRODUCT_STOCK;
+
 import com.ed.productservice.infrastructure.persistence.entity.BaseEntity;
+import com.ed.productservice.libs.common.ProductException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,10 +12,11 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 
 @Entity
-@Table(name = "ed_bottom_size")
+@Table(name = "ed_bottom_size_stock")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BottomSizeEntity extends BaseEntity {
+public class BottomSizeStockEntity extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "bottom_size_id")
@@ -33,11 +37,31 @@ public class BottomSizeEntity extends BaseEntity {
     @Column(name = "hip_width", nullable = false, precision = 5, scale = 1)
     private BigDecimal hipWidth;
 
-    public BottomSizeEntity(Long productId, String bottomSize, BigDecimal totalLength, BigDecimal thighCircumference, BigDecimal hipWidth) {
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+
+    public BottomSizeStockEntity(Long productId, String bottomSize, BigDecimal totalLength,
+        BigDecimal thighCircumference, BigDecimal hipWidth, Integer quantity) {
         this.productId = productId;
         this.bottomSize = bottomSize;
         this.totalLength = totalLength;
         this.thighCircumference = thighCircumference;
         this.hipWidth = hipWidth;
+        this.quantity = quantity;
+    }
+
+    public void validateStockAvailability(int requestQuantity) {
+        if (this.quantity < requestQuantity) {
+            throw new ProductException(INSUFFICIENT_PRODUCT_STOCK);
+        }
+    }
+
+    public void decrease(int quantity) {
+        this.quantity -= quantity;
+    }
+
+    public void increaseStock(int quantity) {
+        this.quantity += quantity;
     }
 }

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/size/TopSizeStockEntity.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/size/TopSizeStockEntity.java
@@ -1,6 +1,9 @@
 package com.ed.productservice.infrastructure.persistence.entity.size;
 
+import static com.ed.productservice.libs.common.ErrorCode.INSUFFICIENT_PRODUCT_STOCK;
+
 import com.ed.productservice.infrastructure.persistence.entity.BaseEntity;
+import com.ed.productservice.libs.common.ProductException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,10 +12,10 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 
 @Entity
-@Table(name = "ed_top_size")
+@Table(name = "ed_top_size_stock")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TopSizeEntity extends BaseEntity {
+public class TopSizeStockEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "top_size_id")
@@ -36,12 +39,32 @@ public class TopSizeEntity extends BaseEntity {
     @Column(name = "sleeve_length", nullable = false)
     private BigDecimal sleeveLength;
 
-    public TopSizeEntity(Long productId, String topSize, BigDecimal totalLength, BigDecimal shoulderWidth, BigDecimal chestWidth, BigDecimal sleeveLength) {
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    public TopSizeStockEntity(Long productId, String topSize, BigDecimal totalLength,
+        BigDecimal shoulderWidth, BigDecimal chestWidth, BigDecimal sleeveLength,
+        Integer quantity) {
         this.productId = productId;
         this.topSize = topSize;
         this.totalLength = totalLength;
         this.shoulderWidth = shoulderWidth;
         this.chestWidth = chestWidth;
         this.sleeveLength = sleeveLength;
+        this.quantity = quantity;
+    }
+
+    public void validateStockAvailability(int requestQuantity) {
+        if (this.quantity < requestQuantity) {
+            throw new ProductException(INSUFFICIENT_PRODUCT_STOCK);
+        }
+    }
+
+    public void decreaseStock(int quantity) {
+        this.quantity -= quantity;
+    }
+
+    public void increaseStock(int quantity) {
+        this.quantity += quantity;
     }
 }

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/size/TopSizeStockEntity.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/entity/size/TopSizeStockEntity.java
@@ -61,6 +61,9 @@ public class TopSizeStockEntity extends BaseEntity {
     }
 
     public void decreaseStock(int quantity) {
+        if (this.quantity < quantity) {
+            throw new ProductException(INSUFFICIENT_PRODUCT_STOCK);
+        }
         this.quantity -= quantity;
     }
 

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/BottomSizeRepository.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/BottomSizeRepository.java
@@ -1,7 +1,0 @@
-package com.ed.productservice.infrastructure.persistence.repository;
-
-import com.ed.productservice.infrastructure.persistence.entity.size.BottomSizeEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface BottomSizeRepository extends JpaRepository<BottomSizeEntity, Long> {
-}

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/BottomSizeStockRepository.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/BottomSizeStockRepository.java
@@ -1,0 +1,13 @@
+package com.ed.productservice.infrastructure.persistence.repository;
+
+import com.ed.productservice.infrastructure.persistence.entity.size.BottomSizeStockEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BottomSizeStockRepository extends JpaRepository<BottomSizeStockEntity, Long> {
+
+    @Query("SELECT b FROM BottomSizeStockEntity b WHERE b.productId = :productId AND b.bottomSize = :size")
+
+    BottomSizeStockEntity findByProductIdAndBottomSize(@Param("productId") Long productId,@Param("size") String size);
+}

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/StockDecreaseHistoryRepository.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/StockDecreaseHistoryRepository.java
@@ -1,0 +1,18 @@
+package com.ed.productservice.infrastructure.persistence.repository;
+
+import com.ed.productservice.infrastructure.persistence.entity.StockDecreaseHistoryEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface StockDecreaseHistoryRepository extends
+    JpaRepository<StockDecreaseHistoryEntity, Long> {
+
+    List<StockDecreaseHistoryEntity> findAllByReservationId(String reservationId);
+
+    @Query("select s from StockDecreaseHistoryEntity s where s.reservationId = :reservationId and s.productId = :productId and s.size =:size")
+    List<StockDecreaseHistoryEntity> findByProductIdAndSizeAndReservationId(@Param("productId") Long productId, @Param("size") String size,
+        @Param("reservationId") String reservationId);
+
+}

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/StockDecreaseHistoryRepository.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/StockDecreaseHistoryRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.repository.query.Param;
 public interface StockDecreaseHistoryRepository extends
     JpaRepository<StockDecreaseHistoryEntity, Long> {
 
-    List<StockDecreaseHistoryEntity> findAllByReservationId(String reservationId);
+    @Query("SELECT s FROM StockDecreaseHistoryEntity s WHERE s.reservationId = :reservationId AND s.isDeleted = false")
+    List<StockDecreaseHistoryEntity> findAllByReservationId(@Param("reservationId") String reservationId);
 
     @Query("select s from StockDecreaseHistoryEntity s where s.reservationId = :reservationId and s.productId = :productId and s.size =:size")
     List<StockDecreaseHistoryEntity> findByProductIdAndSizeAndReservationId(@Param("productId") Long productId, @Param("size") String size,

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/TopSizeRepository.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/TopSizeRepository.java
@@ -1,7 +1,0 @@
-package com.ed.productservice.infrastructure.persistence.repository;
-
-import com.ed.productservice.infrastructure.persistence.entity.size.TopSizeEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface TopSizeRepository extends JpaRepository<TopSizeEntity, Long> {
-}

--- a/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/TopSizeStockRepository.java
+++ b/product-service/src/main/java/com/ed/productservice/infrastructure/persistence/repository/TopSizeStockRepository.java
@@ -1,0 +1,16 @@
+package com.ed.productservice.infrastructure.persistence.repository;
+
+import com.ed.productservice.infrastructure.persistence.entity.size.TopSizeStockEntity;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface TopSizeStockRepository extends JpaRepository<TopSizeStockEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM TopSizeStockEntity t WHERE t.productId = :productId AND t.topSize = :size")
+    TopSizeStockEntity findByProductIdAndTopSize(@Param("productId") Long productId,
+        @Param("size") String size);
+}

--- a/product-service/src/main/java/com/ed/productservice/libs/common/BrandException.java
+++ b/product-service/src/main/java/com/ed/productservice/libs/common/BrandException.java
@@ -1,0 +1,13 @@
+package com.ed.productservice.libs.common;
+
+import lombok.Getter;
+
+@Getter
+public class BrandException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public BrandException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/product-service/src/main/java/com/ed/productservice/libs/common/ErrorCode.java
+++ b/product-service/src/main/java/com/ed/productservice/libs/common/ErrorCode.java
@@ -5,7 +5,13 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-  BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 브랜드를 찾을 수 없습니다.");
+  BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 브랜드를 찾을 수 없습니다."),
+  PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
+  STOCK_RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약된 상품정보를 찾을 수 없습니다."),
+  INVENTORY_RESERVATION_FAILED(HttpStatus.BAD_REQUEST, "재고 예약에 실패했습니다."),
+  INVENTORY_ALREADY_DECREASE(HttpStatus.BAD_REQUEST, "이미 차감된 재고 입니다."),
+  INSUFFICIENT_PRODUCT_STOCK(HttpStatus.CONFLICT, "상품의 재고가 부족합니다.");
+
 
   private final HttpStatus status;
   private final String message;

--- a/product-service/src/main/java/com/ed/productservice/libs/common/GlobalException.java
+++ b/product-service/src/main/java/com/ed/productservice/libs/common/GlobalException.java
@@ -55,14 +55,40 @@ public class GlobalException extends ResponseEntityExceptionHandler {
 		return new ErrorResponse(stackTraces, ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
-	@ExceptionHandler(BrandNotFoundException.class)
-	@ResponseStatus(HttpStatus.NOT_FOUND)
-	public final ErrorResponse handleBrandException(Exception ex, WebRequest request) {
+	@ExceptionHandler(BrandException.class)
+	public ResponseEntity<ErrorResponse> handleBrandException(BrandException ex, WebRequest request) {
 		List<StackTraceElement> stackTraces = null;
 		if (stackTrace) {
 			stackTraces = Arrays.asList(ex.getStackTrace());
 		}
-		logger.error("ERROR ::: [AllException] ", ex);
-		return new ErrorResponse(stackTraces, ex.getMessage(), HttpStatus.NOT_FOUND);
+		logger.error("ERROR ::: [BrandException] ", ex);
+
+		ErrorResponse errorResponse = new ErrorResponse(
+			stackTraces,
+			ex.getMessage(),
+			ex.getErrorCode().getStatus()
+		);
+
+		return ResponseEntity
+			.status(ex.getErrorCode().getStatus())
+			.body(errorResponse);
 	}
+
+	@ExceptionHandler(ProductException.class)
+	public ResponseEntity<ErrorResponse> handleProductException(ProductException ex, WebRequest request) {
+		List<StackTraceElement> stackTraces = null;
+		if (stackTrace) {
+			stackTraces = Arrays.asList(ex.getStackTrace());
+		}
+		logger.error("ERROR ::: [ProductException] ", ex);
+		ErrorResponse errorResponse = new ErrorResponse(
+			stackTraces,
+			ex.getMessage(),
+			ex.getErrorCode().getStatus()
+		);
+
+		return ResponseEntity
+			.status(ex.getErrorCode().getStatus())
+			.body(errorResponse);
+    }
 }

--- a/product-service/src/main/java/com/ed/productservice/libs/common/ProductException.java
+++ b/product-service/src/main/java/com/ed/productservice/libs/common/ProductException.java
@@ -3,10 +3,10 @@ package com.ed.productservice.libs.common;
 import lombok.Getter;
 
 @Getter
-public class BrandNotFoundException extends RuntimeException{
+public class ProductException extends RuntimeException{
     private final ErrorCode errorCode;
 
-    public BrandNotFoundException(ErrorCode errorCode) {
+    public ProductException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }

--- a/product-service/src/main/java/com/ed/productservice/presentation/web/internal/ProductInternalController.java
+++ b/product-service/src/main/java/com/ed/productservice/presentation/web/internal/ProductInternalController.java
@@ -1,0 +1,43 @@
+package com.ed.productservice.presentation.web.internal;
+
+import com.ed.productservice.application.service.internal.ProductInternalService;
+import com.ed.productservice.presentation.web.request.InventoryReservationRequest;
+import com.ed.productservice.presentation.web.response.ProductReservationResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products/internal")
+@RestController
+public class ProductInternalController {
+
+    private final ProductInternalService productInternalService;
+
+    @PostMapping("/inventory/reservations")
+    public ProductReservationResponse reservationStock(
+        @RequestBody InventoryReservationRequest request
+    ) {
+        String reservationId = productInternalService.reservation(request);
+
+        return ProductReservationResponse.from(reservationId);
+    }
+
+    @PostMapping("/inventory/reservations/{reservationId}/decrease")
+    public ProductReservationResponse decreaseStock(@PathVariable("reservationId") String reservationId)
+        throws JsonProcessingException {
+
+        return ProductReservationResponse.from(productInternalService.decreaseStock(reservationId));
+    }
+
+    @PostMapping("/inventory/reservations/{reservationId}/increase")
+    public ProductReservationResponse increaseStock(
+        @PathVariable("reservationId") String reservationId) {
+
+        return ProductReservationResponse.from(productInternalService.increaseStock(reservationId));
+    }
+}

--- a/product-service/src/main/java/com/ed/productservice/presentation/web/internal/ProductInternalController.java
+++ b/product-service/src/main/java/com/ed/productservice/presentation/web/internal/ProductInternalController.java
@@ -35,7 +35,7 @@ public class ProductInternalController {
     }
 
     @PostMapping("/inventory/reservations/{reservationId}/increase")
-    public ProductReservationResponse increaseStock(
+    public ProductReservationResponse rollbackStock(
         @PathVariable("reservationId") String reservationId) {
 
         return ProductReservationResponse.from(productInternalService.increaseStock(reservationId));

--- a/product-service/src/main/java/com/ed/productservice/presentation/web/request/BottomProductCreateRequest.java
+++ b/product-service/src/main/java/com/ed/productservice/presentation/web/request/BottomProductCreateRequest.java
@@ -21,13 +21,16 @@ public record BottomProductCreateRequest(
         private BigDecimal hipWidth;
         private BigDecimal thighWidth;
         private BigDecimal bottomTotalLength;
+        private Integer quantity;
 
-        public BottomSizeRequest(String bottomSize, BigDecimal waistWidth, BigDecimal hipWidth, BigDecimal thighWidth, BigDecimal bottomTotalLength) {
+        public BottomSizeRequest(String bottomSize, BigDecimal waistWidth, BigDecimal hipWidth,
+            BigDecimal thighWidth, BigDecimal bottomTotalLength, Integer quantity) {
             this.bottomSize = bottomSize;
             this.waistWidth = waistWidth;
             this.hipWidth = hipWidth;
             this.thighWidth = thighWidth;
             this.bottomTotalLength = bottomTotalLength;
+            this.quantity = quantity;
         }
     }
 
@@ -46,7 +49,8 @@ public record BottomProductCreateRequest(
                         request.waistWidth,
                         request.hipWidth,
                         request.thighWidth,
-                        request.bottomTotalLength
+                        request.bottomTotalLength,
+                        request.quantity
                 ))
                 .toList();
     }

--- a/product-service/src/main/java/com/ed/productservice/presentation/web/request/InventoryReservationRequest.java
+++ b/product-service/src/main/java/com/ed/productservice/presentation/web/request/InventoryReservationRequest.java
@@ -1,0 +1,15 @@
+package com.ed.productservice.presentation.web.request;
+
+import java.util.List;
+
+public record InventoryReservationRequest(
+    List<ProductReservationInfo> items
+) {
+
+    public record ProductReservationInfo(
+        Long productId,
+        int quantity,
+        String size
+    ) {
+    }
+}

--- a/product-service/src/main/java/com/ed/productservice/presentation/web/request/TopProductCreateRequest.java
+++ b/product-service/src/main/java/com/ed/productservice/presentation/web/request/TopProductCreateRequest.java
@@ -21,13 +21,16 @@ public record TopProductCreateRequest(
         private BigDecimal shoulderWidth;
         private BigDecimal chestWidth;
         private BigDecimal sleeveLength;
+        private Integer quantity;
 
-        public TopSizeRequest(String topSize, BigDecimal totalLength, BigDecimal shoulderWidth, BigDecimal chestWidth, BigDecimal sleeveLength) {
+        public TopSizeRequest(String topSize, BigDecimal totalLength, BigDecimal shoulderWidth,
+            BigDecimal chestWidth, BigDecimal sleeveLength, Integer quantity) {
             this.topSize = topSize;
             this.totalLength = totalLength;
             this.shoulderWidth = shoulderWidth;
             this.chestWidth = chestWidth;
             this.sleeveLength = sleeveLength;
+            this.quantity = quantity;
         }
     }
 
@@ -45,7 +48,8 @@ public record TopProductCreateRequest(
                         request.totalLength,
                         request.shoulderWidth,
                         request.chestWidth,
-                        request.sleeveLength
+                        request.sleeveLength,
+                        request.quantity
                 ))
                 .collect(Collectors.toList());
     }

--- a/product-service/src/main/java/com/ed/productservice/presentation/web/response/ProductReservationResponse.java
+++ b/product-service/src/main/java/com/ed/productservice/presentation/web/response/ProductReservationResponse.java
@@ -1,0 +1,10 @@
+package com.ed.productservice.presentation.web.response;
+
+public record ProductReservationResponse(
+    String reservationId
+) {
+
+    public static ProductReservationResponse from(String reservationId) {
+        return new ProductReservationResponse(reservationId);
+    }
+}

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -15,6 +15,12 @@ spring:
     show-sql: true
     open-in-view: false
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      username: ${REDIS_USERNAME}
+      password: ${REDIS_PASSWORD}
 
 server:
   port: 19094

--- a/product-service/src/test/java/com/ed/productservice/application/service/ProductCreateUseCaseTest.java
+++ b/product-service/src/test/java/com/ed/productservice/application/service/ProductCreateUseCaseTest.java
@@ -61,7 +61,8 @@ class ProductCreateUseCaseTest {
                         new BigDecimal("65.0"),
                         new BigDecimal("42.0"),
                         new BigDecimal("48.0"),
-                        new BigDecimal("61.0")
+                        new BigDecimal("61.0"),
+                    100
                 )
         );
 
@@ -77,7 +78,6 @@ class ProductCreateUseCaseTest {
                 29900,
                 "편안한 착용감의 데일리 티셔츠",
                 "BLACK",
-                100,
                 "top_image_url.jpg",
                 ProductStatus.ACTIVE,
                 ProductCategory.TOP,
@@ -127,7 +127,8 @@ class ProductCreateUseCaseTest {
                         new BigDecimal("32.0"),
                         new BigDecimal("44.0"),
                         new BigDecimal("28.0"),
-                        new BigDecimal("98.0")
+                        new BigDecimal("98.0"),
+                        10
                 )
         );
 
@@ -143,7 +144,6 @@ class ProductCreateUseCaseTest {
                 29900,
                 "편안한 착용감의 데일리 팬츠",
                 "BLACK",
-                100,
                 "bottom_image_url.jpg",
                 ProductStatus.ACTIVE,
                 ProductCategory.BOTTOM,

--- a/product-service/src/test/java/com/ed/productservice/presentation/web/ProductCommandControllerSpringBootTest.java
+++ b/product-service/src/test/java/com/ed/productservice/presentation/web/ProductCommandControllerSpringBootTest.java
@@ -140,21 +140,24 @@ class ProductCommandControllerSpringBootTest {
                         new BigDecimal("32.0"),
                         new BigDecimal("44.0"),
                         new BigDecimal("28.0"),
-                        new BigDecimal("98.0")
+                        new BigDecimal("98.0"),
+                    100
                 ),
                 new BottomProductCreateRequest.BottomSizeRequest(
                         "M",
                         new BigDecimal("34.0"),
                         new BigDecimal("46.0"),
                         new BigDecimal("30.0"),
-                        new BigDecimal("99.0")
+                        new BigDecimal("99.0"),
+                    100
                 ),
                 new BottomProductCreateRequest.BottomSizeRequest(
                         "L",
                         new BigDecimal("36.0"),
                         new BigDecimal("48.0"),
                         new BigDecimal("32.0"),
-                        new BigDecimal("100.0")
+                        new BigDecimal("100.0"),
+                    100
                 )
         );
 
@@ -180,21 +183,24 @@ class ProductCommandControllerSpringBootTest {
                         new BigDecimal("65.0"),
                         new BigDecimal("42.0"),
                         new BigDecimal("48.0"),
-                        new BigDecimal("61.0")
+                        new BigDecimal("61.0"),
+                    10
                 ),
                 new TopProductCreateRequest.TopSizeRequest(
                         "M",
                         new BigDecimal("67.0"),
                         new BigDecimal("44.0"),
                         new BigDecimal("50.0"),
-                        new BigDecimal("62.0")
+                        new BigDecimal("62.0"),
+                    10
                 ),
                 new TopProductCreateRequest.TopSizeRequest(
                         "L",
                         new BigDecimal("69.0"),
                         new BigDecimal("46.0"),
                         new BigDecimal("52.0"),
-                        new BigDecimal("63.0")
+                        new BigDecimal("63.0"),
+                    10
                 )
         );
 

--- a/product-service/src/test/java/com/ed/productservice/presentation/web/ProductCommandControllerWebMvcTest.java
+++ b/product-service/src/test/java/com/ed/productservice/presentation/web/ProductCommandControllerWebMvcTest.java
@@ -60,7 +60,6 @@ class ProductCommandControllerWebMvcTest {
                 29900,
                 "편안한 착용감의 데일리 티셔츠",
                 "BLACK",
-                100,
                 "top_image_url.jpg",
                 ProductStatus.ACTIVE,
                 ProductCategory.TOP,
@@ -99,7 +98,6 @@ class ProductCommandControllerWebMvcTest {
                 29900,
                 "편안한 착용감의 데일리 팬츠",
                 "BLACK",
-                100,
                 "bottom_image_url.jpg",
                 ProductStatus.ACTIVE,
                 ProductCategory.BOTTOM,
@@ -143,21 +141,24 @@ class ProductCommandControllerWebMvcTest {
                         new BigDecimal("32.0"),
                         new BigDecimal("44.0"),
                         new BigDecimal("28.0"),
-                        new BigDecimal("98.0")
+                        new BigDecimal("98.0"),
+                    100
                 ),
                 new BottomProductCreateRequest.BottomSizeRequest(
                         "M",
                         new BigDecimal("34.0"),
                         new BigDecimal("46.0"),
                         new BigDecimal("30.0"),
-                        new BigDecimal("99.0")
+                        new BigDecimal("99.0"),
+                    100
                 ),
                 new BottomProductCreateRequest.BottomSizeRequest(
                         "L",
                         new BigDecimal("36.0"),
                         new BigDecimal("48.0"),
                         new BigDecimal("32.0"),
-                        new BigDecimal("100.0")
+                        new BigDecimal("100.0"),
+                    100
                 )
         );
 
@@ -183,21 +184,24 @@ class ProductCommandControllerWebMvcTest {
                         new BigDecimal("65.0"),
                         new BigDecimal("42.0"),
                         new BigDecimal("48.0"),
-                        new BigDecimal("61.0")
+                        new BigDecimal("61.0"),
+                    10
                 ),
                 new TopProductCreateRequest.TopSizeRequest(
                         "M",
                         new BigDecimal("67.0"),
                         new BigDecimal("44.0"),
                         new BigDecimal("50.0"),
-                        new BigDecimal("62.0")
+                        new BigDecimal("62.0"),
+                    10
                 ),
                 new TopProductCreateRequest.TopSizeRequest(
                         "L",
                         new BigDecimal("69.0"),
                         new BigDecimal("46.0"),
                         new BigDecimal("52.0"),
-                        new BigDecimal("63.0")
+                        new BigDecimal("63.0"),
+                    10
                 )
         );
 

--- a/product-service/src/test/java/com/ed/productservice/presentation/web/internal/ProductInternalControllerTest.java
+++ b/product-service/src/test/java/com/ed/productservice/presentation/web/internal/ProductInternalControllerTest.java
@@ -1,0 +1,243 @@
+package com.ed.productservice.presentation.web.internal;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ed.productservice.application.service.internal.ProductInternalService;
+import com.ed.productservice.domain.vo.BrandType;
+import com.ed.productservice.domain.vo.ProductCategory;
+import com.ed.productservice.domain.vo.ProductStatus;
+import com.ed.productservice.infrastructure.persistence.entity.BrandEntity;
+import com.ed.productservice.infrastructure.persistence.entity.ProductEntity;
+import com.ed.productservice.infrastructure.persistence.entity.size.TopSizeStockEntity;
+import com.ed.productservice.infrastructure.persistence.repository.BrandRepository;
+import com.ed.productservice.infrastructure.persistence.repository.ProductRepository;
+import com.ed.productservice.infrastructure.persistence.repository.TopSizeStockRepository;
+import com.ed.productservice.presentation.web.request.InventoryReservationRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Slf4j
+class ProductInternalControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private BrandRepository brandRepository;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private TopSizeStockRepository topSizeStockRepository;
+    @Autowired
+    private ProductInternalService productInternalService;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("TRUNCATE TABLE ed_brands");
+        jdbcTemplate.execute("TRUNCATE TABLE ed_product");
+        jdbcTemplate.execute("TRUNCATE TABLE ed_top_size_stock");
+
+        BrandEntity brand = brandRepository.save(
+            new BrandEntity("테스트 브랜드", BrandType.CASUAL, "서울특별시"));
+
+        ProductEntity product = productRepository.save(
+            createProduct(brand.getBrandId(), "맨투맨", "M"));
+        ProductEntity product2 = productRepository.save(
+            createProduct(brand.getBrandId(), "후드티", "L"));
+        topSizeStockRepository.save(createTopSizeStock(product.getProductId(), "M"));
+        topSizeStockRepository.save(createTopSizeStock(product2.getProductId(), "L"));
+    }
+
+    private TopSizeStockEntity createTopSizeStock(Long productId, String size) {
+        return new TopSizeStockEntity(
+            productId,
+            size,
+            new BigDecimal("65.0"),
+            new BigDecimal("45.0"),
+            new BigDecimal("50.0"),
+            new BigDecimal("60.0"),
+            100
+        );
+    }
+
+    private ProductEntity createProduct(Long brandId, String name, String size) {
+        return new ProductEntity(
+            UUID.randomUUID().toString(),
+            brandId,
+            name,
+            30000,
+            "테스트 상품입니다",
+            "BLACK",
+            "test-image.jpg",
+            ProductStatus.ACTIVE,
+            ProductCategory.TOP
+        );
+    }
+
+    @Test
+    @DisplayName("재고 예약 요청시 reservationId를 반환한다")
+    void t1() throws Exception {
+
+        InventoryReservationRequest request = new InventoryReservationRequest(
+            List.of(
+                new InventoryReservationRequest.ProductReservationInfo(1L, 1, "M"),
+                new InventoryReservationRequest.ProductReservationInfo(2L, 2, "L")
+            )
+        );
+
+        String content = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(request);
+
+        mockMvc.perform(post("/api/v1/products/internal/inventory/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.body.reservationId").exists())
+            .andExpect(jsonPath("$.timestamp").exists())
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("재고보다 많은 수량을 예약 요청시 실패한다")
+    void t2() throws Exception {
+        InventoryReservationRequest request = new InventoryReservationRequest(
+            List.of(
+                new InventoryReservationRequest.ProductReservationInfo(1L, 1000, "M")
+            )
+        );
+
+        String content = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(request);
+
+        mockMvc.perform(post("/api/v1/products/internal/inventory/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.body.message").exists())
+            .andExpect(jsonPath("$.body.status").value("BAD_REQUEST"))
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("재고 차감 요청 시 reservationId 반환")
+    void t3() throws Exception {
+        InventoryReservationRequest request = new InventoryReservationRequest(
+            List.of(
+                new InventoryReservationRequest.ProductReservationInfo(1L, 5, "M"),
+                new InventoryReservationRequest.ProductReservationInfo(2L, 5, "L")
+            )
+        );
+
+        String reservationId = productInternalService.reservation(request);
+
+        mockMvc.perform(
+                post("/api/v1/products/internal/inventory/reservations/{reservationId}/decrease",
+                    reservationId)
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.body.reservationId").value(reservationId))
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 예약 ID로 재고 차감 요청시 실패한다")
+    void t4() throws Exception {
+        String reservationId = "testId";
+
+        mockMvc.perform(post("/api/v1/products/internal/inventory/reservations/{reservationId}/decrease", reservationId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.body.message").exists())
+            .andExpect(jsonPath("$.body.status").value("NOT_FOUND"))
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("재고 차감 중복 요청 시 에러 반환")
+    void t5() throws Exception {
+        InventoryReservationRequest request = new InventoryReservationRequest(
+            List.of(
+                new InventoryReservationRequest.ProductReservationInfo(1L, 5, "M")
+            )
+        );
+
+        String reservationId = productInternalService.reservation(request);
+
+        mockMvc.perform(
+                post("/api/v1/products/internal/inventory/reservations/{reservationId}/decrease",
+                    reservationId)
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/products/internal/inventory/reservations/{reservationId}/decrease", reservationId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.body.message").exists())
+            .andExpect(jsonPath("$.body.status").value("BAD_REQUEST"))
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("재고 롤백 요청 후 reservationId 반환")
+    void t6() throws Exception {
+        InventoryReservationRequest request = new InventoryReservationRequest(
+            List.of(
+                new InventoryReservationRequest.ProductReservationInfo(1L, 5, "M")
+            )
+        );
+
+        String reservationId = productInternalService.reservation(request);
+
+        mockMvc.perform(
+                post("/api/v1/products/internal/inventory/reservations/{reservationId}/decrease",
+                    reservationId)
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/products/internal/inventory/reservations/{reservationId}/increase", reservationId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.body.reservationId").value(reservationId))
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("재고 차감 롤백 요청 시 history 테이블에 존재하지 않는 예약정보면 404 반환")
+    void t7() throws Exception {
+        String reservationId = "testId";
+
+        mockMvc.perform(post("/api/v1/products/internal/inventory/reservations/{reservationId}/increase", reservationId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.body.status").value("NOT_FOUND"))
+            .andDo(print());
+    }
+
+}

--- a/product-service/src/test/resources/application-test.yml
+++ b/product-service/src/test/resources/application-test.yml
@@ -1,4 +1,10 @@
 spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
   jpa:
     show-sql: true
     hibernate:


### PR DESCRIPTION

## 🔖 연관된 이슈
#9 

## 📂 작업 내용
- **재고 예약** [API 문서](https://www.notion.so/f96c968b13cb40ecbcfea313dcda026a)
  - 재고 예약 시 reservationId 생성 후 상품 정보와 함께 Redis 저장
  - 주문서비스에 reservationId 반환

- **재고 차감** [API 문서](https://www.notion.so/98afd7a1705142f7b2151fec577ae1ff)
  - 주문서비스에서 reservationId 받은 후 Redis에서 예약된 정보 조회 
  - 각 재고 테이블 수량 차감 로직 실행
  - 재고 차감 전 이력 테이블 조회로 중복 차감 방지 
  - 차감후 재고 이력 테이블에 정보 저장

- **재고 차감 롤백** [API 문서](https://www.notion.so/7e8c590f18f54453bb05213e65c8da56)
  - reservationId 받아와 재고 이력 테이블에 조회
  - 카테고리별 재고 수량 원복
  - 해당 데이터 재고 이력 테이블 isDeleted() 실행 

- **통합테스트**
  - 재고 예약, 차감, 롤백 통합테스트 작성

## 📢 리뷰 참고사항