### PR TITLE
[Feature/Settlement-Service] 일일 정산

### DIFF
--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -52,12 +52,20 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-thymeleaf:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
 
+    // batch
+    implementation "org.springframework.boot:spring-boot-starter-batch:${springBootVersion}"
+
     // db
     implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
     runtimeOnly "com.mysql:mysql-connector-j:${mysqlConnectorVersion}"
 
+    // QueryDsl
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
     // kafka
-    implementation "com.google.code.gson:gson:${gsonVersion}"
     implementation "org.springframework.kafka:spring-kafka:${springKafkaVersion}"
     testImplementation "org.springframework.kafka:spring-kafka-test:${springKafkaVersion}"
     avroTools "org.apache.avro:avro-tools:${avroToolsVersion}"
@@ -65,6 +73,7 @@ dependencies {
 
     // eureka
     implementation "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:${springCloudVersion}"
+    implementation "org.springframework.cloud:spring-cloud-starter-openfeign:${springCloudVersion}"
 
     // lombok
     compileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/payment-service/gradle.properties
+++ b/payment-service/gradle.properties
@@ -17,3 +17,5 @@ junitPlatformVersion=1.11.4
 dotenvVersion=3.1.0
 # Apache Http Client
 apacheHttpclientVersion=4.5.14
+# QueryDSL
+querydslVersion=5.0.0

--- a/payment-service/src/main/java/com/ed/payment/PaymentServiceApplication.java
+++ b/payment-service/src/main/java/com/ed/payment/PaymentServiceApplication.java
@@ -2,7 +2,9 @@ package com.ed.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class PaymentServiceApplication {
 

--- a/payment-service/src/main/java/com/ed/payment/application/port/out/feign/GetOrderSettlementsPort.java
+++ b/payment-service/src/main/java/com/ed/payment/application/port/out/feign/GetOrderSettlementsPort.java
@@ -1,0 +1,8 @@
+package com.ed.payment.application.port.out.feign;
+
+import com.ed.payment.application.port.out.feign.dtos.OrderSettlementResponse;
+import java.util.List;
+
+public interface GetOrderSettlementsPort {
+  List<OrderSettlementResponse> getOrderSettlements(List<String> orderPublicIds);
+}

--- a/payment-service/src/main/java/com/ed/payment/application/port/out/feign/dtos/OrderSettlementResponse.java
+++ b/payment-service/src/main/java/com/ed/payment/application/port/out/feign/dtos/OrderSettlementResponse.java
@@ -1,0 +1,31 @@
+package com.ed.payment.application.port.out.feign.dtos;
+
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class OrderSettlementResponse {
+
+  private String orderPublicId;
+  private List<OrderItemDetail> orderItems;
+
+  @Getter
+  public static class OrderItemDetail {
+
+    private String orderItemPublicId;
+    private String brandPublicId;
+    private String productPublicId;
+    private int quantity;
+    private Long unitPrice;
+    private CouponDetail coupon;
+  }
+
+  @Getter
+  public static class CouponDetail {
+
+    private String couponTemplatePublicId;
+    private String orderCouponPublicId;
+    private BigDecimal discountAmount;
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/application/port/out/persistence/CreateDailySettlementPort.java
+++ b/payment-service/src/main/java/com/ed/payment/application/port/out/persistence/CreateDailySettlementPort.java
@@ -1,0 +1,8 @@
+package com.ed.payment.application.port.out.persistence;
+
+import com.ed.payment.domain.DailySettlement;
+import java.util.List;
+
+public interface CreateDailySettlementPort {
+  void bulkCreateDailySettlement(List<DailySettlement> settlementSummaries);
+}

--- a/payment-service/src/main/java/com/ed/payment/application/port/out/persistence/GetPaymentPort.java
+++ b/payment-service/src/main/java/com/ed/payment/application/port/out/persistence/GetPaymentPort.java
@@ -1,11 +1,14 @@
 package com.ed.payment.application.port.out.persistence;
 
 import com.ed.payment.application.port.out.persistence.dtos.PaymentResponse;
+import com.ed.payment.application.port.out.persistence.dtos.SettleablePaymentResponse;
 import com.ed.payment.domain.Payment;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface GetPaymentPort {
   boolean existsByOrderPublicId(String orderPublicId);
   List<PaymentResponse> getReadyPayments(String userPublicId);
   Payment getPaymentByOrderPublicId(String orderPublicId);
+  List<SettleablePaymentResponse> getSettleablePayments(LocalDateTime requestDateTime, Long currentId, int pageSize);
 }

--- a/payment-service/src/main/java/com/ed/payment/application/port/out/persistence/UpdatePaymentPort.java
+++ b/payment-service/src/main/java/com/ed/payment/application/port/out/persistence/UpdatePaymentPort.java
@@ -2,9 +2,11 @@ package com.ed.payment.application.port.out.persistence;
 
 import com.ed.payment.application.port.out.persistence.dtos.UpdateCancelPaymentRequest;
 import com.ed.payment.domain.PaymentStatus;
+import java.util.List;
 
 public interface UpdatePaymentPort {
   void updatePaymentStatusAbortedById(Long paymentId);
+  void bulkUpdatePaymentStatusByIds(List<Long> paymentIds);
   void updatePaymentStatusAndPaymentKeyById(Long paymentId, PaymentStatus paymentStatus, String paymentKey);
   void updatePaymentStatusAndIdempotencyKeyById(UpdateCancelPaymentRequest request);
 }

--- a/payment-service/src/main/java/com/ed/payment/application/port/out/persistence/dtos/SettleablePaymentResponse.java
+++ b/payment-service/src/main/java/com/ed/payment/application/port/out/persistence/dtos/SettleablePaymentResponse.java
@@ -1,0 +1,16 @@
+package com.ed.payment.application.port.out.persistence.dtos;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
+public class SettleablePaymentResponse {
+
+  private Long paymentId;
+  private String orderPublicId;
+}

--- a/payment-service/src/main/java/com/ed/payment/domain/DailySettlement.java
+++ b/payment-service/src/main/java/com/ed/payment/domain/DailySettlement.java
@@ -1,0 +1,62 @@
+package com.ed.payment.domain;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.ed.payment.application.port.out.feign.dtos.OrderSettlementResponse;
+import com.ed.payment.application.port.out.feign.dtos.OrderSettlementResponse.OrderItemDetail;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+public class DailySettlement {
+
+  private static final BigDecimal COMMISSION_RATE = BigDecimal.valueOf(0.1);
+
+  private String orderPublicId;
+  private String brandPublicId;
+  private String productPublicId;
+  private BigDecimal netRevenue;
+  private BigDecimal discountAmount;
+  private BigDecimal commission;
+
+  public static List<DailySettlement> from(List<OrderSettlementResponse> responses) {
+    return responses.stream()
+        .flatMap(response -> response.getOrderItems().stream()
+            .map(orderItem -> createFromOrderItem(response.getOrderPublicId(), orderItem)))
+        .toList();
+  }
+
+  private static DailySettlement createFromOrderItem(String orderPublicId, OrderItemDetail orderItem) {
+
+    BigDecimal totalAmount = calculateTotalRevenue(orderItem.getUnitPrice(), orderItem.getQuantity());
+    BigDecimal commission = calculateCommission(totalAmount);
+    BigDecimal netRevenue = totalAmount.subtract(getDiscountAmount(orderItem)).subtract(commission);
+
+    return DailySettlement.builder()
+        .orderPublicId(orderPublicId)
+        .brandPublicId(orderItem.getBrandPublicId())
+        .productPublicId(orderItem.getProductPublicId())
+        .netRevenue(netRevenue)
+        .discountAmount(getDiscountAmount(orderItem))
+        .commission(commission)
+        .build();
+  }
+
+  private static BigDecimal getDiscountAmount(OrderItemDetail orderItem) {
+    return orderItem.getCoupon() == null ?  BigDecimal.ZERO : orderItem.getCoupon().getDiscountAmount();
+  }
+
+  private static BigDecimal calculateCommission(BigDecimal totalAmount) {
+    return totalAmount.multiply(COMMISSION_RATE);
+  }
+
+  private static BigDecimal calculateTotalRevenue(Long unitPrice, int quantity) {
+    return BigDecimal.valueOf(unitPrice)
+        .multiply(BigDecimal.valueOf(quantity));
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/domain/PaymentStatus.java
+++ b/payment-service/src/main/java/com/ed/payment/domain/PaymentStatus.java
@@ -5,7 +5,8 @@ public enum PaymentStatus {
   DONE,
   PARTIAL_CANCELED,
   CANCELED,
-  ABORTED
+  ABORTED,
+  SETTLEMENT_COMPLETE
   ;
 
   public static boolean isConfirmed(PaymentStatus paymentStatus) {

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/batch/chunk/reader/SettleablePaymentCustomItemReader.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/batch/chunk/reader/SettleablePaymentCustomItemReader.java
@@ -1,0 +1,45 @@
+package com.ed.payment.infrastructure.out.batch.chunk.reader;
+
+import com.ed.payment.application.port.out.persistence.GetPaymentPort;
+import com.ed.payment.application.port.out.persistence.dtos.SettleablePaymentResponse;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.batch.item.database.AbstractPagingItemReader;
+
+public class SettleablePaymentCustomItemReader extends
+    AbstractPagingItemReader<SettleablePaymentResponse> {
+
+    private final GetPaymentPort getPaymentPort;
+    private final LocalDateTime requestDateTime;
+    private final int pageSize;
+    private Long currentId = null;
+
+    public SettleablePaymentCustomItemReader(LocalDateTime requestDateTime, GetPaymentPort getPaymentPort, int pageSize) {
+        this.getPaymentPort = getPaymentPort;
+        this.requestDateTime = requestDateTime;
+        this.pageSize = pageSize;
+        setPageSize(pageSize);
+    }
+
+    @Override
+    protected void doReadPage() {
+
+        if (results == null) {
+            results = new ArrayList<>();
+        } else {
+            results.clear();
+        }
+
+        List<SettleablePaymentResponse> settleablePayments = getPaymentPort
+            .getSettleablePayments(requestDateTime, currentId, pageSize);
+
+        results.addAll(settleablePayments);
+
+        if (!results.isEmpty()) {
+            currentId = results.getLast().getPaymentId();
+        } else {
+            currentId = null;
+        }
+    }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/batch/chunk/reader/SettleablePaymentReaderConfig.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/batch/chunk/reader/SettleablePaymentReaderConfig.java
@@ -1,0 +1,24 @@
+package com.ed.payment.infrastructure.out.batch.chunk.reader;
+
+import com.ed.payment.application.port.out.persistence.GetPaymentPort;
+import com.ed.payment.application.port.out.persistence.dtos.SettleablePaymentResponse;
+import java.time.LocalDateTime;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.database.AbstractPagingItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SettleablePaymentReaderConfig {
+
+  private static final int DEFAULT_PAGE_SIZE = 5000;
+
+  @Bean
+  @StepScope
+  public AbstractPagingItemReader<SettleablePaymentResponse> settleablePaymentItemReader(
+      @Value("#{jobParameters['requestDateTime']}") LocalDateTime requestDateTime,
+      GetPaymentPort getPaymentPort) {
+    return new SettleablePaymentCustomItemReader(requestDateTime, getPaymentPort, DEFAULT_PAGE_SIZE);
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/batch/chunk/writer/DailySettlementItemWriter.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/batch/chunk/writer/DailySettlementItemWriter.java
@@ -1,0 +1,47 @@
+package com.ed.payment.infrastructure.out.batch.chunk.writer;
+
+import com.ed.payment.application.port.out.feign.GetOrderSettlementsPort;
+import com.ed.payment.application.port.out.feign.dtos.OrderSettlementResponse;
+import com.ed.payment.application.port.out.persistence.CreateDailySettlementPort;
+import com.ed.payment.application.port.out.persistence.UpdatePaymentPort;
+import com.ed.payment.application.port.out.persistence.dtos.SettleablePaymentResponse;
+import com.ed.payment.domain.DailySettlement;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DailySettlementItemWriter implements ItemWriter<SettleablePaymentResponse> {
+
+  private final GetOrderSettlementsPort getOrderSettlementsPort;
+  private final CreateDailySettlementPort createDailySettlementPort;
+  private final UpdatePaymentPort updatePaymentPort;
+
+  @Override
+  public void write(Chunk<? extends SettleablePaymentResponse> chunk) {
+
+    List<OrderSettlementResponse> orderSettlementResponses =
+        getOrderSettlementsPort.getOrderSettlements(getOrderPublicIds(chunk));
+
+    List<DailySettlement> dailySettlements = DailySettlement.from(orderSettlementResponses);
+
+    createDailySettlementPort.bulkCreateDailySettlement(dailySettlements);
+
+    updatePaymentPort.bulkUpdatePaymentStatusByIds(getPaymentsIds(chunk));
+  }
+
+  private List<String> getOrderPublicIds(Chunk<? extends SettleablePaymentResponse> chunk) {
+    return chunk.getItems().stream()
+        .map(SettleablePaymentResponse::getOrderPublicId)
+        .toList();
+  }
+
+  private List<Long> getPaymentsIds(Chunk<? extends SettleablePaymentResponse> chunk) {
+    return chunk.getItems().stream()
+        .map(SettleablePaymentResponse::getPaymentId)
+        .toList();
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/batch/job/DailySettlementJobConfig.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/batch/job/DailySettlementJobConfig.java
@@ -1,0 +1,47 @@
+package com.ed.payment.infrastructure.out.batch.job;
+
+import com.ed.payment.application.port.out.persistence.dtos.SettleablePaymentResponse;
+import com.ed.payment.infrastructure.out.batch.listener.JobDurationListener;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.support.DefaultBatchConfiguration;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.AbstractPagingItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableTransactionManagement
+public class DailySettlementJobConfig extends DefaultBatchConfiguration {
+
+  private static final String JOB_NAME = "dailySettlementJob";
+  private static final String STEP_NAME = "dailySettlementStep";
+  private static final int DEFAULT_CHUNK_SIZE = 5000;
+
+  private final AbstractPagingItemReader<SettleablePaymentResponse> settleablePaymentItemReader;
+  private final ItemWriter<SettleablePaymentResponse> dailySettlementItemWriter;
+
+  @Bean
+  public Job dailySettlementJob(JobRepository jobRepository, Step dailySettlementStep) {
+    return new JobBuilder(JOB_NAME, jobRepository)
+        .listener(new JobDurationListener())
+        .start(dailySettlementStep)
+        .build();
+  }
+
+  @Bean
+  public Step dailySettlementStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+    return new StepBuilder(STEP_NAME, jobRepository)
+        .<SettleablePaymentResponse, SettleablePaymentResponse>chunk(DEFAULT_CHUNK_SIZE, transactionManager)
+        .reader(settleablePaymentItemReader)
+        .writer(dailySettlementItemWriter)
+        .build();
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/batch/listener/JobDurationListener.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/batch/listener/JobDurationListener.java
@@ -1,0 +1,28 @@
+package com.ed.payment.infrastructure.out.batch.listener;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+
+@Slf4j
+public class JobDurationListener implements JobExecutionListener {
+
+    private LocalDateTime startTime;
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        startTime = LocalDateTime.now();
+        log.info("Job '{}' started at {}", jobExecution.getJobInstance().getJobName(), startTime);
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        LocalDateTime endTime = LocalDateTime.now();
+        log.info("Job '{}' finished at {}", jobExecution.getJobInstance().getJobName(), endTime);
+
+        Duration duration = Duration.between(startTime, endTime);
+        log.info("Job '{}' total duration: {} seconds", jobExecution.getJobInstance().getJobName(), duration.getSeconds());
+    }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/feign/config/FeignClientConfig.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/feign/config/FeignClientConfig.java
@@ -1,0 +1,14 @@
+package com.ed.payment.infrastructure.out.feign.config;
+
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignClientConfig {
+
+  @Bean
+  public ErrorDecoder errorDecoder() {
+    return new FeignErrorDecoder();
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/feign/config/FeignErrorDecoder.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/feign/config/FeignErrorDecoder.java
@@ -1,0 +1,33 @@
+package com.ed.payment.infrastructure.out.feign.config;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+
+public class FeignErrorDecoder implements ErrorDecoder {
+
+  private final ErrorDecoder defaultErrorDecoder = new Default();
+
+  @Override
+  public Exception decode(String methodKey, Response response) {
+    try {
+      String responseBody = IOUtils.toString(response.body().asInputStream(),
+          StandardCharsets.UTF_8);
+
+      return switch (response.status()) {
+        case 400 -> new BadRequestException(responseBody);
+        case 404 -> new NotFoundException(responseBody);
+        case 500 -> new InternalServerErrorException(responseBody);
+        default -> defaultErrorDecoder.decode(methodKey, response);
+      };
+
+    } catch (IOException e) {
+      return new Exception("Failed to process response body");
+    }
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/feign/domain/order/OrderClient.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/feign/domain/order/OrderClient.java
@@ -1,0 +1,16 @@
+package com.ed.payment.infrastructure.out.feign.domain.order;
+
+import com.ed.payment.application.port.out.feign.dtos.OrderSettlementResponse;
+import com.ed.payment.infrastructure.out.feign.config.FeignClientConfig;
+import com.ed.payment.libs.common.response.ApiResponse;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "order-service", configuration = FeignClientConfig.class)
+interface OrderClient {
+
+  @PostMapping("/api/v1/internal/orders/settlements")
+  ApiResponse<List<OrderSettlementResponse>> getOrderSettlement(@RequestBody List<String> orderPublicIds);
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/feign/domain/order/OrderFeignAdapter.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/feign/domain/order/OrderFeignAdapter.java
@@ -1,0 +1,19 @@
+package com.ed.payment.infrastructure.out.feign.domain.order;
+
+import com.ed.payment.application.port.out.feign.GetOrderSettlementsPort;
+import com.ed.payment.application.port.out.feign.dtos.OrderSettlementResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class OrderFeignAdapter implements GetOrderSettlementsPort {
+
+  private final OrderClient orderClient;
+
+  @Override
+  public List<OrderSettlementResponse> getOrderSettlements(List<String> orderPublicIds) {
+    return orderClient.getOrderSettlement(orderPublicIds).getBody();
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/config/QueryDslConfig.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.ed.payment.infrastructure.out.persistence.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/entity/DailySettlementJpaEntity.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/entity/DailySettlementJpaEntity.java
@@ -1,0 +1,59 @@
+package com.ed.payment.infrastructure.out.persistence.entity;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import com.ed.payment.libs.common.entity.BaseTimeJpaEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ED_DAILY_SETTLEMENT")
+@NoArgsConstructor(access = PROTECTED)
+public class DailySettlementJpaEntity extends BaseTimeJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "DAILY_SETTLEMENT_ID")
+    private Long id;
+
+    @Column(name = "ORDER_PUBLIC_ID")
+    private String orderPublicId;
+
+    @Column(name = "BRAND_PUBLIC_ID")
+    private String brandPublicId;
+
+    @Column(name = "PRODUCT_PUBLIC_ID")
+    private String productPublicId;
+
+    @Column(name = "NET_REVENUE")
+    private BigDecimal netRevenue;
+
+    @Column(name = "DISCOUNT_AMOUNT")
+    private BigDecimal discountAmount;
+
+    @Column(name = "COMMISSION")
+    private BigDecimal commission;
+
+    @Column(name = "SETTLED_AT")
+    private LocalDateTime settledAt;
+
+    @Builder(builderMethodName = "createDailySettlement", builderClassName = "CreateDailySettlement")
+    private DailySettlementJpaEntity(String brandPublicId, String orderPublicId,
+        String productPublicId, BigDecimal netRevenue, BigDecimal discountAmount, BigDecimal commission) {
+        this.orderPublicId = orderPublicId;
+        this.brandPublicId = brandPublicId;
+        this.productPublicId = productPublicId;
+        this.netRevenue = netRevenue;
+        this.discountAmount = discountAmount;
+        this.commission = commission;
+        this.settledAt = LocalDateTime.now();
+    }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/entity/MonthlySettlementJpaEntity.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/entity/MonthlySettlementJpaEntity.java
@@ -1,0 +1,40 @@
+package com.ed.payment.infrastructure.out.persistence.entity;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import com.ed.payment.libs.common.entity.BaseTimeJpaEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ED_MONTHLY_SETTLEMENT")
+@NoArgsConstructor(access = PROTECTED)
+public class MonthlySettlementJpaEntity extends BaseTimeJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "MONTHLY_SETTLEMENT_ID")
+    private Long id;
+
+    @Column(name = "BRAND_PUBLIC_ID")
+    private String brandPublicId;
+
+    @Column(name = "TOTAL_NET_REVENUE")
+    private BigDecimal totalNetRevenue;
+
+    @Column(name = "TOTAL_DISCOUNT_AMOUNT")
+    private BigDecimal totalDiscountAmount;
+
+    @Column(name = "TOTAL_COMMISSION")
+    private BigDecimal totalCommission;
+
+    @Column(name = "SETTLED_AT")
+    private LocalDateTime settledAt;
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/entity/PaymentJpaEntity.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/entity/PaymentJpaEntity.java
@@ -3,7 +3,6 @@ package com.ed.payment.infrastructure.out.persistence.entity;
 import static com.ed.payment.domain.PaymentStatus.ABORTED;
 import static com.ed.payment.domain.PaymentStatus.READY;
 import static com.ed.payment.domain.PaymentStatus.getCancelPaymentStatus;
-import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.ed.payment.domain.PaymentStatus;
@@ -22,7 +21,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,7 +28,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "ED_PAYMENT")
-@AllArgsConstructor(access = PRIVATE)
 @NoArgsConstructor(access = PROTECTED)
 public class PaymentJpaEntity extends BaseTimeJpaEntity {
 

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/repository/DailySettlementPersistenceAdapter.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/repository/DailySettlementPersistenceAdapter.java
@@ -1,0 +1,38 @@
+package com.ed.payment.infrastructure.out.persistence.repository;
+
+import com.ed.payment.application.port.out.persistence.CreateDailySettlementPort;
+import com.ed.payment.domain.DailySettlement;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+class DailySettlementPersistenceAdapter implements CreateDailySettlementPort {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  @Override
+  public void bulkCreateDailySettlement(List<DailySettlement> dailySettlements) {
+      String sql = "INSERT INTO ED_DAILY_SETTLEMENT (ORDER_PUBLIC_ID, BRAND_PUBLIC_ID, PRODUCT_PUBLIC_ID, NET_REVENUE, DISCOUNT_AMOUNT, COMMISSION, SETTLED_AT, CREATED_AT, UPDATED_AT, IS_DELETED) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+      jdbcTemplate.batchUpdate(sql, dailySettlements, dailySettlements.size(),
+          (PreparedStatement ps, DailySettlement data) -> {
+              ps.setString(1, data.getOrderPublicId());
+              ps.setString(2, data.getBrandPublicId());
+              ps.setString(3, data.getProductPublicId());
+              ps.setBigDecimal(4, data.getNetRevenue());
+              ps.setBigDecimal(5, data.getDiscountAmount());
+              ps.setBigDecimal(6, data.getCommission());
+              ps.setTimestamp(7, Timestamp.valueOf(LocalDateTime.now()));
+              ps.setTimestamp(8, Timestamp.valueOf(LocalDateTime.now()));
+              ps.setTimestamp(9, Timestamp.valueOf(LocalDateTime.now()));
+              ps.setBoolean(10, false);
+          });
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/repository/PaymentPersistenceAdapter.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/repository/PaymentPersistenceAdapter.java
@@ -2,13 +2,15 @@ package com.ed.payment.infrastructure.out.persistence.repository;
 
 import static com.ed.payment.domain.PaymentStatus.CANCELED;
 import static com.ed.payment.domain.PaymentStatus.DONE;
+import static com.ed.payment.domain.PaymentStatus.SETTLEMENT_COMPLETE;
 import static com.ed.payment.libs.common.exception.ErrorCode.PAYMENT_NOT_FOUND;
 
 import com.ed.payment.application.port.out.persistence.CreatePaymentPort;
 import com.ed.payment.application.port.out.persistence.GetPaymentPort;
+import com.ed.payment.application.port.out.persistence.UpdatePaymentPort;
 import com.ed.payment.application.port.out.persistence.dtos.CreatePaymentRequest;
 import com.ed.payment.application.port.out.persistence.dtos.PaymentResponse;
-import com.ed.payment.application.port.out.persistence.UpdatePaymentPort;
+import com.ed.payment.application.port.out.persistence.dtos.SettleablePaymentResponse;
 import com.ed.payment.application.port.out.persistence.dtos.UpdateCancelPaymentRequest;
 import com.ed.payment.domain.Payment;
 import com.ed.payment.domain.PaymentStatus;
@@ -25,6 +27,7 @@ class PaymentPersistenceAdapter implements CreatePaymentPort, GetPaymentPort, Up
 
   private final PaymentPersistenceMapper paymentPersistenceMapper;
   private final SpringDataPaymentRepository paymentRepository;
+  private final PaymentQueryDslAdapter paymentQueryDslAdapter;
 
   @Override
   public Payment createPayment(CreatePaymentRequest request) {
@@ -41,7 +44,7 @@ class PaymentPersistenceAdapter implements CreatePaymentPort, GetPaymentPort, Up
   public List<PaymentResponse> getReadyPayments(String userPublicId) {
     List<PaymentJpaEntity> entities = paymentRepository.findMyReadyPayments(userPublicId, List.of(DONE, CANCELED), LocalDateTime.now());
     return entities.stream()
-        .map(paymentPersistenceMapper::mapToApplication)
+        .map(paymentPersistenceMapper::mapToPaymentResponse)
         .toList();
   }
 
@@ -53,8 +56,19 @@ class PaymentPersistenceAdapter implements CreatePaymentPort, GetPaymentPort, Up
   }
 
   @Override
+  public List<SettleablePaymentResponse> getSettleablePayments(
+      LocalDateTime requestDateTime, Long currentId, int pageSize) {
+    return paymentQueryDslAdapter.findSettleablePayments(requestDateTime, currentId, pageSize);
+  }
+
+  @Override
   public void updatePaymentStatusAbortedById(Long paymentId) {
     getPaymentJpaEntity(paymentId).fail();
+  }
+
+  @Override
+  public void bulkUpdatePaymentStatusByIds(List<Long> paymentIds) {
+    paymentRepository.bulkUpdatePaymentStatus(paymentIds, SETTLEMENT_COMPLETE);
   }
 
   @Override

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/repository/PaymentPersistenceMapper.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/repository/PaymentPersistenceMapper.java
@@ -24,7 +24,7 @@ class PaymentPersistenceMapper {
     return paymentJpaEntity;
   }
 
-  PaymentResponse mapToApplication(PaymentJpaEntity entity) {
+  PaymentResponse mapToPaymentResponse(PaymentJpaEntity entity) {
     return PaymentResponse.builder()
         .paymentPublicId(entity.getUserPublicId())
         .idempotencyKey(entity.getIdempotencyKey())

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/repository/PaymentQueryDslAdapter.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/repository/PaymentQueryDslAdapter.java
@@ -1,0 +1,38 @@
+package com.ed.payment.infrastructure.out.persistence.repository;
+
+import static com.ed.payment.domain.PaymentStatus.DONE;
+import static com.ed.payment.domain.PaymentStatus.PARTIAL_CANCELED;
+import static com.ed.payment.infrastructure.out.persistence.entity.QPaymentJpaEntity.paymentJpaEntity;
+
+import com.ed.payment.application.port.out.persistence.dtos.SettleablePaymentResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+class PaymentQueryDslAdapter {
+
+  private final JPAQueryFactory queryFactory;
+
+  public List<SettleablePaymentResponse> findSettleablePayments(LocalDateTime requestDateTime, Long currentId, int pageSize) {
+    return queryFactory
+        .select(Projections.constructor(SettleablePaymentResponse.class,
+            paymentJpaEntity.id, paymentJpaEntity.orderPublicId))
+        .from(paymentJpaEntity)
+        .where(paymentJpaEntity.paymentStatus.in(DONE, PARTIAL_CANCELED)
+            .and(paymentJpaEntity.cancelDeadLine.before(requestDateTime))
+            .and(paymentIdGt(currentId)))
+        .orderBy(paymentJpaEntity.id.asc())
+        .limit(pageSize)
+        .fetch();
+  }
+
+  private BooleanExpression paymentIdGt(Long currentId) {
+    return currentId != null ? paymentJpaEntity.id.gt(currentId) : null;
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/repository/SpringDataPaymentRepository.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/persistence/repository/SpringDataPaymentRepository.java
@@ -6,14 +6,22 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 interface SpringDataPaymentRepository extends JpaRepository<PaymentJpaEntity, Long> {
+
   boolean existsByOrderPublicId(String orderPublicId);
+
   Optional<PaymentJpaEntity> findByOrderPublicId(String orderPublicId);
+
   @Query("SELECT p FROM PaymentJpaEntity p " +
       "WHERE p.userPublicId = :userPublicId " +
       "AND p.paymentStatus NOT IN :paymentStatuses " +
       "AND p.confirmDeadline > :requestDateTime")
   List<PaymentJpaEntity> findMyReadyPayments(String userPublicId, List<PaymentStatus> paymentStatuses, LocalDateTime requestDateTime);
+
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE PaymentJpaEntity p SET p.paymentStatus = :paymentStatus WHERE p.id IN :ids")
+  void bulkUpdatePaymentStatus(List<Long> ids, PaymentStatus paymentStatus);
 }

--- a/payment-service/src/main/java/com/ed/payment/infrastructure/out/scheduler/DailySettlementBatchScheduler.java
+++ b/payment-service/src/main/java/com/ed/payment/infrastructure/out/scheduler/DailySettlementBatchScheduler.java
@@ -1,0 +1,33 @@
+package com.ed.payment.infrastructure.out.scheduler;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class DailySettlementBatchScheduler {
+
+  private final JobLauncher jobLauncher;
+  private final Job dailySettlementJob;
+
+  @Scheduled(cron = "00 19 10 * * *")
+  public void runSettlementJob()
+      throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
+    JobParameters jobParameters = new JobParametersBuilder()
+        .addLocalDateTime("requestDateTime", LocalDateTime.now())
+        .toJobParameters();
+    jobLauncher.run(dailySettlementJob, jobParameters);
+  }
+}

--- a/payment-service/src/main/java/com/ed/payment/libs/common/response/ApiResponse.java
+++ b/payment-service/src/main/java/com/ed/payment/libs/common/response/ApiResponse.java
@@ -5,9 +5,11 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class ApiResponse<T> {
 	private Boolean success;

--- a/payment-service/src/main/java/com/ed/payment/presentation/in/web/RequestPaymentViewController.java
+++ b/payment-service/src/main/java/com/ed/payment/presentation/in/web/RequestPaymentViewController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class RequestPaymentViewController {
 
-  @GetMapping("/payments/widget")
+  @GetMapping("/api/v1/payments/widget")
   public String checkout() {
     return "checkout";
   }

--- a/payment-service/src/main/resources/application-dev.yml
+++ b/payment-service/src/main/resources/application-dev.yml
@@ -15,6 +15,10 @@ spring:
     show-sql: true
     open-in-view: false
 
+  batch:
+    jdbc:
+      initialize-schema: never
+
   sql:
     init:
       mode: always

--- a/payment-service/src/main/resources/schema.sql
+++ b/payment-service/src/main/resources/schema.sql
@@ -1,42 +1,184 @@
+DROP TABLE IF EXISTS BATCH_STEP_EXECUTION_CONTEXT;
+DROP TABLE IF EXISTS BATCH_JOB_EXECUTION_CONTEXT;
+DROP TABLE IF EXISTS BATCH_STEP_EXECUTION;
+DROP TABLE IF EXISTS BATCH_JOB_EXECUTION_PARAMS;
+DROP TABLE IF EXISTS BATCH_JOB_EXECUTION;
+DROP TABLE IF EXISTS BATCH_JOB_INSTANCE;
+
+DROP TABLE IF EXISTS BATCH_STEP_EXECUTION_SEQ;
+DROP TABLE IF EXISTS BATCH_JOB_EXECUTION_SEQ;
+DROP TABLE IF EXISTS BATCH_JOB_SEQ;
+
+CREATE TABLE BATCH_JOB_INSTANCE  (
+    JOB_INSTANCE_ID BIGINT  NOT NULL PRIMARY KEY ,
+    VERSION BIGINT ,
+    JOB_NAME VARCHAR(100) NOT NULL,
+    JOB_KEY VARCHAR(32) NOT NULL,
+    constraint JOB_INST_UN unique (JOB_NAME, JOB_KEY)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_JOB_EXECUTION  (
+    JOB_EXECUTION_ID BIGINT  NOT NULL PRIMARY KEY ,
+    VERSION BIGINT  ,
+    JOB_INSTANCE_ID BIGINT NOT NULL,
+    CREATE_TIME DATETIME(6) NOT NULL,
+    START_TIME DATETIME(6) DEFAULT NULL ,
+    END_TIME DATETIME(6) DEFAULT NULL ,
+    STATUS VARCHAR(10) ,
+    EXIT_CODE VARCHAR(2500) ,
+    EXIT_MESSAGE VARCHAR(2500) ,
+    LAST_UPDATED DATETIME(6),
+    constraint JOB_INST_EXEC_FK foreign key (JOB_INSTANCE_ID)
+      references BATCH_JOB_INSTANCE(JOB_INSTANCE_ID)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_JOB_EXECUTION_PARAMS  (
+    JOB_EXECUTION_ID BIGINT NOT NULL ,
+    PARAMETER_NAME VARCHAR(100) NOT NULL ,
+    PARAMETER_TYPE VARCHAR(100) NOT NULL ,
+    PARAMETER_VALUE VARCHAR(2500) ,
+    IDENTIFYING CHAR(1) NOT NULL ,
+    constraint JOB_EXEC_PARAMS_FK foreign key (JOB_EXECUTION_ID)
+     references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_STEP_EXECUTION  (
+    STEP_EXECUTION_ID BIGINT  NOT NULL PRIMARY KEY ,
+    VERSION BIGINT NOT NULL,
+    STEP_NAME VARCHAR(100) NOT NULL,
+    JOB_EXECUTION_ID BIGINT NOT NULL,
+    CREATE_TIME DATETIME(6) NOT NULL,
+    START_TIME DATETIME(6) DEFAULT NULL ,
+    END_TIME DATETIME(6) DEFAULT NULL ,
+    STATUS VARCHAR(10) ,
+    COMMIT_COUNT BIGINT ,
+    READ_COUNT BIGINT ,
+    FILTER_COUNT BIGINT ,
+    WRITE_COUNT BIGINT ,
+    READ_SKIP_COUNT BIGINT ,
+    WRITE_SKIP_COUNT BIGINT ,
+    PROCESS_SKIP_COUNT BIGINT ,
+    ROLLBACK_COUNT BIGINT ,
+    EXIT_CODE VARCHAR(2500) ,
+    EXIT_MESSAGE VARCHAR(2500) ,
+    LAST_UPDATED DATETIME(6),
+    constraint JOB_EXEC_STEP_FK foreign key (JOB_EXECUTION_ID)
+       references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_STEP_EXECUTION_CONTEXT  (
+    STEP_EXECUTION_ID BIGINT NOT NULL PRIMARY KEY,
+    SHORT_CONTEXT VARCHAR(2500) NOT NULL,
+    SERIALIZED_CONTEXT TEXT ,
+    constraint STEP_EXEC_CTX_FK foreign key (STEP_EXECUTION_ID)
+       references BATCH_STEP_EXECUTION(STEP_EXECUTION_ID)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_JOB_EXECUTION_CONTEXT  (
+    JOB_EXECUTION_ID BIGINT NOT NULL PRIMARY KEY,
+    SHORT_CONTEXT VARCHAR(2500) NOT NULL,
+    SERIALIZED_CONTEXT TEXT ,
+    constraint JOB_EXEC_CTX_FK foreign key (JOB_EXECUTION_ID)
+      references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_STEP_EXECUTION_SEQ (
+    ID BIGINT NOT NULL,
+    UNIQUE_KEY CHAR(1) NOT NULL,
+    constraint UNIQUE_KEY_UN unique (UNIQUE_KEY)
+) ENGINE=InnoDB;
+
+INSERT INTO BATCH_STEP_EXECUTION_SEQ (ID, UNIQUE_KEY) select * from (select 0 as ID, '0' as UNIQUE_KEY) as tmp where not exists(select * from BATCH_STEP_EXECUTION_SEQ);
+
+CREATE TABLE BATCH_JOB_EXECUTION_SEQ (
+    ID BIGINT NOT NULL,
+    UNIQUE_KEY CHAR(1) NOT NULL,
+    constraint UNIQUE_KEY_UN unique (UNIQUE_KEY)
+) ENGINE=InnoDB;
+
+INSERT INTO BATCH_JOB_EXECUTION_SEQ (ID, UNIQUE_KEY) select * from (select 0 as ID, '0' as UNIQUE_KEY) as tmp where not exists(select * from BATCH_JOB_EXECUTION_SEQ);
+
+CREATE TABLE BATCH_JOB_SEQ (
+    ID BIGINT NOT NULL,
+    UNIQUE_KEY CHAR(1) NOT NULL,
+    constraint UNIQUE_KEY_UN unique (UNIQUE_KEY)
+) ENGINE=InnoDB;
+
+INSERT INTO BATCH_JOB_SEQ (ID, UNIQUE_KEY) select * from (select 0 as ID, '0' as UNIQUE_KEY) as tmp where not exists(select * from BATCH_JOB_SEQ);
+
 DROP TABLE if EXISTS ED_PAYMENT;
 DROP TABLE if EXISTS ED_PAYMENT_HISTORY;
+DROP TABLE if EXISTS ED_DAILY_SETTLEMENT;
+DROP TABLE if EXISTS ED_MONTHLY_SETTLEMENT;
 
 CREATE TABLE `ED_PAYMENT`
 (
-    `PAYMENT_ID`                BIGINT                                                                              NOT NULL AUTO_INCREMENT                     COMMENT '결제 PK',
-    `PAYMENT_PUBLIC_ID`         VARCHAR(36)                                                                         DEFAULT NULL                                COMMENT '결제 외부 공개 ID',
-    `PAYMENT_KEY`               VARCHAR(200)                                                                        DEFAULT NULL                                COMMENT 'TossPayments 식별자',
-    `IDEMPOTENCY_KEY`           VARCHAR(36)                                                                         DEFAULT NULL                                COMMENT '멱등키',
-    `USER_PUBLIC_ID`            VARCHAR(36)                                                                         NOT NULL                                    COMMENT '사용자의 외부 공개 ID',
-    `PAYMENT_STATUS`            ENUM('READY','VERIFY_FAILED', 'DONE', 'PARTIAL_CANCELED', 'CANCELED', 'ABORTED')    NOT NULL                                    COMMENT '결제 상태',
-    `ORDER_PUBLIC_ID`           CHAR(18)                                                                            NOT NULL                                    COMMENT '주문 외부 공개 ID',
-    `ORDER_NAME`                VARCHAR(255)                                                                        NOT NULL                                    COMMENT '주문명',
-    `TOTAL_AMOUNT`              BIGINT                                                                              DEFAULT NULL                                COMMENT '총 결제 금액',
-    `BALANCE_AMOUNT`            BIGINT                                                                              DEFAULT NULL                                COMMENT '취소 가능 금액',
-    `CONFIRM_DEADLINE`          TIMESTAMP                                                                           NOT NULL                                    COMMENT '결제 승인 유효기한',
-    `CANCEL_DEADLINE`           TIMESTAMP                                                                           NOT NULL                                    COMMENT '결제 취소 유효기한',
-    `CREATED_AT`                TIMESTAMP                                                                           NOT NULL                                    COMMENT '결제 데이터 생성일',
-    `UPDATED_AT`                TIMESTAMP                                                                           DEFAULT NULL                                COMMENT '결제 데이터 수정일',
-    `DELETED_AT`                TIMESTAMP                                                                           DEFAULT NULL                                COMMENT '결제 데이터 삭제일',
-    `IS_DELETED`                BIT(1)                                                                              NOT NULL                                    COMMENT '결제 데이터 삭제 여부',
+    `PAYMENT_ID`                BIGINT                                                                                                      NOT NULL AUTO_INCREMENT                     COMMENT '결제 PK',
+    `PAYMENT_PUBLIC_ID`         VARCHAR(36)                                                                                                 DEFAULT NULL                                COMMENT '결제 외부 공개 ID',
+    `PAYMENT_KEY`               VARCHAR(200)                                                                                                DEFAULT NULL                                COMMENT 'TossPayments 식별자',
+    `IDEMPOTENCY_KEY`           VARCHAR(36)                                                                                                 DEFAULT NULL                                COMMENT '멱등키',
+    `USER_PUBLIC_ID`            VARCHAR(36)                                                                                                 NOT NULL                                    COMMENT '사용자의 외부 공개 ID',
+    `PAYMENT_STATUS`            ENUM('READY','VERIFY_FAILED', 'DONE', 'PARTIAL_CANCELED', 'CANCELED', 'ABORTED', 'SETTLEMENT_COMPLETE')     NOT NULL                                    COMMENT '결제 상태',
+    `ORDER_PUBLIC_ID`           CHAR(18)                                                                                                    NOT NULL                                    COMMENT '주문 외부 공개 ID',
+    `ORDER_NAME`                VARCHAR(255)                                                                                                NOT NULL                                    COMMENT '주문명',
+    `TOTAL_AMOUNT`              BIGINT                                                                                                      DEFAULT NULL                                COMMENT '총 결제 금액',
+    `BALANCE_AMOUNT`            BIGINT                                                                                                      DEFAULT NULL                                COMMENT '취소 가능 금액',
+    `CONFIRM_DEADLINE`          TIMESTAMP                                                                                                   NOT NULL                                    COMMENT '결제 승인 유효기한',
+    `CANCEL_DEADLINE`           TIMESTAMP                                                                                                   NOT NULL                                    COMMENT '결제 취소 유효기한',
+    `CREATED_AT`                TIMESTAMP                                                                                                   NOT NULL                                    COMMENT '결제 데이터 생성일',
+    `UPDATED_AT`                TIMESTAMP                                                                                                   DEFAULT NULL                                COMMENT '결제 데이터 수정일',
+    `DELETED_AT`                TIMESTAMP                                                                                                   DEFAULT NULL                                COMMENT '결제 데이터 삭제일',
+    `IS_DELETED`                BIT(1)                                                                                                      NOT NULL                                    COMMENT '결제 데이터 삭제 여부',
     PRIMARY KEY (`PAYMENT_ID`),
     UNIQUE KEY `UKMBQSCLI8W5457J9WLLJ1IJP30` (`PAYMENT_PUBLIC_ID`),
     UNIQUE KEY `UK2M21C5PKJISKFQHNXSL3U5L3V` (`PAYMENT_KEY`),
     UNIQUE KEY `UKDM29Y305P71XAP9LQ3UITWI25` (`ORDER_PUBLIC_ID`)
-) ENGINE=INNODB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin                                                                                   COMMENT='업데이트된 결제 정보를 저장하는 테이블';
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin                                                                                                                             COMMENT='업데이트된 결제 정보를 저장하는 테이블';
 
 CREATE TABLE `ED_PAYMENT_HISTORY`
 (
-    `PAYMENT_HISTORY_ID`        BIGINT                                                                              NOT NULL AUTO_INCREMENT                     COMMENT '결제 히스토리 PK',
-    `PAYMENT_HISTORY_PUBLIC_ID` VARCHAR(36)                                                                         NOT NULL                                    COMMENT '결제 히스토리 외부 공개 ID',
-    `PAYMENT_ID`                BIGINT                                                                              NOT NULL                                    COMMENT '결제 PK',
-    `PAYMENT_STATUS`            ENUM('READY','VERIFY_FAILED', 'DONE', 'PARTIAL_CANCELED', 'CANCELED', 'ABORTED')    NOT NULL                                    COMMENT '결제 상태',
-    `CANCEL_AMOUNT`             BIGINT                                                                              DEFAULT NULL                                COMMENT '취소 금액',
-    `CANCEL_REASON`             VARCHAR(255)                                                                        DEFAULT NULL                                COMMENT '취소 이유',
-    `CREATED_AT`                TIMESTAMP                                                                           NOT NULL                                    COMMENT '결제 히스토리 데이터 생성일',
-    `UPDATED_AT`                TIMESTAMP                                                                           DEFAULT NULL                                COMMENT '결제 히스토리 데이터 수정일',
-    `DELETED_AT`                TIMESTAMP                                                                           DEFAULT NULL                                COMMENT '결제 히스토리 데이터 삭제일',
-    `IS_DELETED`                BIT(1)                                                                              NOT NULL                                    COMMENT '결제 히스토리 데이터 삭제 여부',
+    `PAYMENT_HISTORY_ID`        BIGINT                                                                                                      NOT NULL AUTO_INCREMENT                     COMMENT '결제 히스토리 PK',
+    `PAYMENT_HISTORY_PUBLIC_ID` VARCHAR(36)                                                                                                 NOT NULL                                    COMMENT '결제 히스토리 외부 공개 ID',
+    `PAYMENT_ID`                BIGINT                                                                                                      NOT NULL                                    COMMENT '결제 PK',
+    `PAYMENT_STATUS`            ENUM('READY','VERIFY_FAILED', 'DONE', 'PARTIAL_CANCELED', 'CANCELED', 'ABORTED', 'SETTLEMENT_COMPLETE')     NOT NULL                                    COMMENT '결제 상태',
+    `CANCEL_AMOUNT`             BIGINT                                                                                                      DEFAULT NULL                                COMMENT '취소 금액',
+    `CANCEL_REASON`             VARCHAR(255)                                                                                                DEFAULT NULL                                COMMENT '취소 이유',
+    `CREATED_AT`                TIMESTAMP                                                                                                   NOT NULL                                    COMMENT '결제 히스토리 데이터 생성일',
+    `UPDATED_AT`                TIMESTAMP                                                                                                   DEFAULT NULL                                COMMENT '결제 히스토리 데이터 수정일',
+    `DELETED_AT`                TIMESTAMP                                                                                                   DEFAULT NULL                                COMMENT '결제 히스토리 데이터 삭제일',
+    `IS_DELETED`                BIT(1)                                                                                                      NOT NULL                                    COMMENT '결제 히스토리 데이터 삭제 여부',
     PRIMARY KEY (`PAYMENT_HISTORY_ID`),
     UNIQUE KEY `UK9T6O3DCIN5TSFFKR69GIINPO5` (`PAYMENT_HISTORY_PUBLIC_ID`)
-) ENGINE=INNODB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin                                                                                   COMMENT='모든 결제 히스토리 정보를 저장하는 테이블';
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin                                                                                                                             COMMENT='모든 결제 히스토리 정보를 저장하는 테이블';
+
+CREATE TABLE `ED_DAILY_SETTLEMENT`
+(
+    `DAILY_SETTLEMENT_ID`       BIGINT                                                                                                      NOT NULL AUTO_INCREMENT                     COMMENT '일일 정산 PK',
+    `ORDER_PUBLIC_ID`           VARCHAR(18)                                                                                                 NOT NULL                                    COMMENT '브랜드 외부 공개 ID',
+    `BRAND_PUBLIC_ID`           VARCHAR(36)                                                                                                 NOT NULL                                    COMMENT '주문 외부 공개 ID',
+    `PRODUCT_PUBLIC_ID`         VARCHAR(36)                                                                                                 NOT NULL                                    COMMENT '상품 외부 공개 ID',
+    `NET_REVENUE`               DECIMAL(38, 2)                                                                                              NOT NULL                                    COMMENT '순수익',
+    `DISCOUNT_AMOUNT`           DECIMAL(38, 2)                                                                                              NOT NULL                                    COMMENT '할인 금액',
+    `COMMISSION`                DECIMAL(38, 2)                                                                                              DEFAULT NULL                                COMMENT '수수료',
+    `SETTLED_AT`                TIMESTAMP                                                                                                   NOT NULL                                    COMMENT '정산일',
+    `CREATED_AT`                TIMESTAMP                                                                                                   NOT NULL                                    COMMENT '일일 정산 데이터 생성일',
+    `UPDATED_AT`                TIMESTAMP                                                                                                   DEFAULT NULL                                COMMENT '일일 정산 데이터 수정일',
+    `DELETED_AT`                TIMESTAMP                                                                                                   DEFAULT NULL                                COMMENT '일일 정산 데이터 삭제일',
+    `IS_DELETED`                BIT(1)                                                                                                      NOT NULL                                    COMMENT '일일 정산 데이터 삭제 여부',
+    PRIMARY KEY (`DAILY_SETTLEMENT_ID`)
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin                                                                                                                             COMMENT='일일 정산 정보를 저장하는 테이블';
+
+CREATE TABLE `ED_MONTHLY_SETTLEMENT`
+(
+    `MONTHLY_SETTLEMENT_ID`     BIGINT                                                                                                      NOT NULL AUTO_INCREMENT                     COMMENT '정산 상세 PK',
+    `BRAND_PUBLIC_ID`           VARCHAR(36)                                                                                                 NOT NULL                                    COMMENT '브랜드 외부 공개 ID',
+    `TOTAL_NET_REVENUE`         DECIMAL(38, 2)                                                                                              NOT NULL                                    COMMENT '총 순수익',
+    `TOTAL_DISCOUNT_AMOUNT`     DECIMAL(38, 2)                                                                                              NOT NULL                                    COMMENT '총 할인 금액',
+    `TOTAL_COMMISSION`          DECIMAL(38, 2)                                                                                              NOT NULL                                    COMMENT '총 수수료',
+    `SETTLED_AT`                TIMESTAMP                                                                                                   NOT NULL                                    COMMENT '정산일',
+    `CREATED_AT`                TIMESTAMP                                                                                                   NOT NULL                                    COMMENT '월간 정산 데이터 생성일',
+    `UPDATED_AT`                TIMESTAMP                                                                                                   DEFAULT NULL                                COMMENT '월간 정산 데이터 수정일',
+    `DELETED_AT`                TIMESTAMP                                                                                                   DEFAULT NULL                                COMMENT '월간 정산 데이터 삭제일',
+    `IS_DELETED`                BIT(1)                                                                                                      NOT NULL                                    COMMENT '월간 정산 데이터 삭제 여부',
+    PRIMARY KEY (`MONTHLY_SETTLEMENT_ID`)
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin                                                                                                                             COMMENT='월간 정산 정보를 저장하는 테이블';


### PR DESCRIPTION
## 🔖 연관된 이슈
<!-- 연관된 이슈 번호를 작성해 주세요 -->
#52

## 📂 작업 내용
<!-- 작업한 내용을 작성해 주세요 -->
- 매일 새벽 4시에 정산 가능 결제 리스트를 조회한다.
- 조회한 결제 리스트 데이터의 주문 아이디를 가지고 주문 서비스에 feign client 요청한다.
- 응답 받은 데이터를 기반으로 정산하고 정산 데이터를 저장한다.
- 결제 상태를 정산 완료로 변경한다.

## 📢 리뷰 참고사항
<!-- 리뷰시 참고사항을 작성해 주세요 -->